### PR TITLE
Better names for section variables

### DIFF
--- a/lib/Benchmarks/BabyIP.v
+++ b/lib/Benchmarks/BabyIP.v
@@ -98,7 +98,7 @@ Module BabyIP2.
     match s with
     | Start =>
       {| st_op := extract(HdrCombi);
-         st_trans := transition select (| (EHdr (sz := sz) HdrCombi)[19 -- 16] |) {{
+         st_trans := transition select (| (EHdr (Hdr_sz := sz) HdrCombi)[19 -- 16] |) {{
           [| exact #b|0|0|0|1 |] ==> accept ;;;
           [| exact #b|0|0|0|0 |] ==> inl ParseSeq ;;;
             reject

--- a/lib/Benchmarks/Ethernet.v
+++ b/lib/Benchmarks/Ethernet.v
@@ -101,7 +101,7 @@ Module Combined.
     match s with
     | Parse =>
       {| st_op := extract(HdrVar);
-        st_trans := transition select (| (EHdr (sz := sz) HdrVar)[176 -- 160] |) {{
+        st_trans := transition select (| (EHdr (Hdr_sz := sz) HdrVar)[176 -- 160] |) {{
           [| exact #b|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0 |] ==> accept ;;;
             @reject state
         }}

--- a/lib/Benchmarks/IPFilter.v
+++ b/lib/Benchmarks/IPFilter.v
@@ -55,7 +55,7 @@ Module UDPInterleaved.
     match s with
     | ParseIP =>
       {| st_op := extract(HdrIP);
-         st_trans := transition select (| (EHdr (sz := sz) HdrIP)[43 -- 40] |) {{
+         st_trans := transition select (| (EHdr (Hdr_sz := sz) HdrIP)[43 -- 40] |) {{
            [| exact #b|0|0|0|1 |] ==> inl ParseUDP ;;;
            [| exact #b|0|0|0|0 |] ==> inl ParseTCP ;;;
             reject
@@ -110,7 +110,7 @@ Module UDPCombined.
       {| st_op :=
           extract(HdrIP) ;;
           extract(HdrPref) ;
-          st_trans := transition select (| (EHdr (sz := sz) HdrIP)[43 -- 40] |) {{
+          st_trans := transition select (| (EHdr (Hdr_sz := sz) HdrIP)[43 -- 40] |) {{
             [| exact #b|0|0|0|1 |] ==> accept ;;;
             [| exact #b|0|0|0|0 |] ==> inl ParseSuf ;;;
              reject

--- a/lib/Benchmarks/IPOptions.v
+++ b/lib/Benchmarks/IPOptions.v
@@ -208,7 +208,7 @@ Module IPOptionsRef10.
       {| st_op :=
           extract(T0) ;;
           extract(L0) ;
-         st_trans := transition select (| EHdr (sz := sz)T0, EHdr (sz := sz)L0 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz)T0, EHdr (Hdr_sz := sz)L0 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse01 ;;;
@@ -225,43 +225,43 @@ Module IPOptionsRef10.
     | Parse01 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V0 <- EConcat (m := 56) (EHdr (sz := sz)Scratch8) ((EHdr (sz := sz)V0)[64--8]) ;
+          V0 <- EConcat (m := 56) (EHdr (Hdr_sz := sz)Scratch8) ((EHdr (Hdr_sz := sz)V0)[64--8]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse02 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V0 <- EConcat (m := 48) (EHdr (sz := sz)Scratch16) ((EHdr (sz := sz)V0)[64--16]) ;
+          V0 <- EConcat (m := 48) (EHdr (Hdr_sz := sz)Scratch16) ((EHdr (Hdr_sz := sz)V0)[64--16]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse03 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V0 <- EConcat (m := 40) (EHdr (sz := sz)Scratch24) ((EHdr (sz := sz)V0)[64--24]) ;
+          V0 <- EConcat (m := 40) (EHdr (Hdr_sz := sz)Scratch24) ((EHdr (Hdr_sz := sz)V0)[64--24]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse04 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V0 <- EConcat (m := 32) (EHdr (sz := sz)Scratch32) ((EHdr (sz := sz)V0)[64--32]) ;
+          V0 <- EConcat (m := 32) (EHdr (Hdr_sz := sz)Scratch32) ((EHdr (Hdr_sz := sz)V0)[64--32]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse05 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V0 <- EConcat (m := 24) (EHdr (sz := sz)Scratch40) ((EHdr (sz := sz)V0)[64--40]) ;
+          V0 <- EConcat (m := 24) (EHdr (Hdr_sz := sz)Scratch40) ((EHdr (Hdr_sz := sz)V0)[64--40]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse06 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V0 <- EConcat (m := 16) (EHdr (sz := sz)Scratch48) ((EHdr (sz := sz)V0)[64--48]) ;
+          V0 <- EConcat (m := 16) (EHdr (Hdr_sz := sz)Scratch48) ((EHdr (Hdr_sz := sz)V0)[64--48]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse07 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V0 <- EConcat (m := 8) (EHdr (sz := sz)Scratch56) ((EHdr (sz := sz)V0)[64--56]) ;
+          V0 <- EConcat (m := 8) (EHdr (Hdr_sz := sz)Scratch56) ((EHdr (Hdr_sz := sz)V0)[64--56]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse08 =>
@@ -274,7 +274,7 @@ Module IPOptionsRef10.
       {| st_op :=
           extract(T1) ;;
           extract(L1) ;
-         st_trans := transition select (| EHdr (sz := sz)T1, EHdr (sz := sz)L1 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz)T1, EHdr (Hdr_sz := sz)L1 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse11 ;;;
@@ -291,43 +291,43 @@ Module IPOptionsRef10.
     | Parse11 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 56) (EHdr (sz := sz)Scratch8) ((EHdr (sz := sz)V1)[64--8]) ;
+          V1 <- EConcat (m := 56) (EHdr (Hdr_sz := sz)Scratch8) ((EHdr (Hdr_sz := sz)V1)[64--8]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse12 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 48) (EHdr (sz := sz)Scratch16) ((EHdr (sz := sz)V1)[64--16]) ;
+          V1 <- EConcat (m := 48) (EHdr (Hdr_sz := sz)Scratch16) ((EHdr (Hdr_sz := sz)V1)[64--16]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse13 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V1 <- EConcat (m := 40) (EHdr (sz := sz)Scratch24) ((EHdr (sz := sz)V1)[64--24]) ;
+          V1 <- EConcat (m := 40) (EHdr (Hdr_sz := sz)Scratch24) ((EHdr (Hdr_sz := sz)V1)[64--24]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse14 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V1 <- EConcat (m := 32) (EHdr (sz := sz)Scratch32) ((EHdr (sz := sz)V1)[64--32]) ;
+          V1 <- EConcat (m := 32) (EHdr (Hdr_sz := sz)Scratch32) ((EHdr (Hdr_sz := sz)V1)[64--32]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse15 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V1 <- EConcat (m := 24) (EHdr (sz := sz)Scratch40) ((EHdr (sz := sz)V1)[64--40]) ;
+          V1 <- EConcat (m := 24) (EHdr (Hdr_sz := sz)Scratch40) ((EHdr (Hdr_sz := sz)V1)[64--40]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse16 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V1 <- EConcat (m := 16) (EHdr (sz := sz)Scratch48) ((EHdr (sz := sz)V1)[64--48]) ;
+          V1 <- EConcat (m := 16) (EHdr (Hdr_sz := sz)Scratch48) ((EHdr (Hdr_sz := sz)V1)[64--48]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse17 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V1 <- EConcat (m := 8) (EHdr (sz := sz)Scratch56) ((EHdr (sz := sz)V1)[64--56]) ;
+          V1 <- EConcat (m := 8) (EHdr (Hdr_sz := sz)Scratch56) ((EHdr (Hdr_sz := sz)V1)[64--56]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse18 =>
@@ -340,7 +340,7 @@ Module IPOptionsRef10.
       {| st_op :=
           extract(T2) ;;
           extract(L2) ;
-         st_trans := transition select (| EHdr (sz := sz)T2, EHdr (sz := sz)L2 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz)T2, EHdr (Hdr_sz := sz)L2 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse21 ;;;
@@ -357,43 +357,43 @@ Module IPOptionsRef10.
     | Parse21 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 56) (EHdr (sz := sz)Scratch8) ((EHdr (sz := sz)V2)[64--8]) ;
+          V1 <- EConcat (m := 56) (EHdr (Hdr_sz := sz)Scratch8) ((EHdr (Hdr_sz := sz)V2)[64--8]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse22 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V2 <- EConcat (m := 48) (EHdr (sz := sz)Scratch16) ((EHdr (sz := sz)V2)[64--16]) ;
+          V2 <- EConcat (m := 48) (EHdr (Hdr_sz := sz)Scratch16) ((EHdr (Hdr_sz := sz)V2)[64--16]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse23 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V2 <- EConcat (m := 40) (EHdr (sz := sz)Scratch24) ((EHdr (sz := sz)V2)[64--24]) ;
+          V2 <- EConcat (m := 40) (EHdr (Hdr_sz := sz)Scratch24) ((EHdr (Hdr_sz := sz)V2)[64--24]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse24 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V2 <- EConcat (m := 32) (EHdr (sz := sz)Scratch32) ((EHdr (sz := sz)V2)[64--32]) ;
+          V2 <- EConcat (m := 32) (EHdr (Hdr_sz := sz)Scratch32) ((EHdr (Hdr_sz := sz)V2)[64--32]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse25 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V2 <- EConcat (m := 24) (EHdr (sz := sz)Scratch40) ((EHdr (sz := sz)V2)[64--40]) ;
+          V2 <- EConcat (m := 24) (EHdr (Hdr_sz := sz)Scratch40) ((EHdr (Hdr_sz := sz)V2)[64--40]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse26 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V2 <- EConcat (m := 16) (EHdr (sz := sz)Scratch48) ((EHdr (sz := sz)V2)[64--48]) ;
+          V2 <- EConcat (m := 16) (EHdr (Hdr_sz := sz)Scratch48) ((EHdr (Hdr_sz := sz)V2)[64--48]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse27 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V2 <- EConcat (m := 8) (EHdr (sz := sz)Scratch56) ((EHdr (sz := sz)V2)[64--56]) ;
+          V2 <- EConcat (m := 8) (EHdr (Hdr_sz := sz)Scratch56) ((EHdr (Hdr_sz := sz)V2)[64--56]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse28 =>
@@ -406,7 +406,7 @@ Module IPOptionsRef10.
       {| st_op :=
           extract(T3) ;;
           extract(L3) ;
-         st_trans := transition select (| EHdr (sz := sz)T3, EHdr (sz := sz)L3 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz)T3, EHdr (Hdr_sz := sz)L3 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse31 ;;;
@@ -423,43 +423,43 @@ Module IPOptionsRef10.
     | Parse31 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V3 <- EConcat (m := 56) (EHdr (sz := sz)Scratch8) ((EHdr (sz := sz)V3)[64--8]) ;
+          V3 <- EConcat (m := 56) (EHdr (Hdr_sz := sz)Scratch8) ((EHdr (Hdr_sz := sz)V3)[64--8]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse32 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V3 <- EConcat (m := 48) (EHdr (sz := sz)Scratch16) ((EHdr (sz := sz)V3)[64--16]) ;
+          V3 <- EConcat (m := 48) (EHdr (Hdr_sz := sz)Scratch16) ((EHdr (Hdr_sz := sz)V3)[64--16]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse33 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V3 <- EConcat (m := 40) (EHdr (sz := sz)Scratch24) ((EHdr (sz := sz)V3)[64--24]) ;
+          V3 <- EConcat (m := 40) (EHdr (Hdr_sz := sz)Scratch24) ((EHdr (Hdr_sz := sz)V3)[64--24]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse34 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V3 <- EConcat (m := 32) (EHdr (sz := sz)Scratch32) ((EHdr (sz := sz)V3)[64--32]) ;
+          V3 <- EConcat (m := 32) (EHdr (Hdr_sz := sz)Scratch32) ((EHdr (Hdr_sz := sz)V3)[64--32]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse35 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V3 <- EConcat (m := 24) (EHdr (sz := sz)Scratch40) ((EHdr (sz := sz)V3)[64--40]) ;
+          V3 <- EConcat (m := 24) (EHdr (Hdr_sz := sz)Scratch40) ((EHdr (Hdr_sz := sz)V3)[64--40]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse36 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V3 <- EConcat (m := 16) (EHdr (sz := sz)Scratch48) ((EHdr (sz := sz)V3)[64--48]) ;
+          V3 <- EConcat (m := 16) (EHdr (Hdr_sz := sz)Scratch48) ((EHdr (Hdr_sz := sz)V3)[64--48]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse37 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V3 <- EConcat (m := 8) (EHdr (sz := sz)Scratch56) ((EHdr (sz := sz)V3)[64--56]) ;
+          V3 <- EConcat (m := 8) (EHdr (Hdr_sz := sz)Scratch56) ((EHdr (Hdr_sz := sz)V3)[64--56]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse38 =>
@@ -472,7 +472,7 @@ Module IPOptionsRef10.
       {| st_op :=
           extract(T4) ;;
           extract(L4) ;
-         st_trans := transition select (| EHdr (sz := sz)T4, EHdr (sz := sz)L4 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz)T4, EHdr (Hdr_sz := sz)L4 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse41 ;;;
@@ -489,43 +489,43 @@ Module IPOptionsRef10.
     | Parse41 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V4 <- EConcat (m := 56) (EHdr (sz := sz)Scratch8) ((EHdr (sz := sz)V4)[64--8]) ;
+          V4 <- EConcat (m := 56) (EHdr (Hdr_sz := sz)Scratch8) ((EHdr (Hdr_sz := sz)V4)[64--8]) ;
          st_trans := transition inl Parse5;
       |}
     | Parse42 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V4 <- EConcat (m := 48) (EHdr (sz := sz)Scratch16) ((EHdr (sz := sz)V4)[64--16]) ;
+          V4 <- EConcat (m := 48) (EHdr (Hdr_sz := sz)Scratch16) ((EHdr (Hdr_sz := sz)V4)[64--16]) ;
          st_trans := transition inl Parse5;
       |}
     | Parse43 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V4 <- EConcat (m := 40) (EHdr (sz := sz)Scratch24) ((EHdr (sz := sz)V4)[64--24]) ;
+          V4 <- EConcat (m := 40) (EHdr (Hdr_sz := sz)Scratch24) ((EHdr (Hdr_sz := sz)V4)[64--24]) ;
          st_trans := transition inl Parse5;
       |}
     | Parse44 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V4 <- EConcat (m := 32) (EHdr (sz := sz)Scratch32) ((EHdr (sz := sz)V4)[64--32]) ;
+          V4 <- EConcat (m := 32) (EHdr (Hdr_sz := sz)Scratch32) ((EHdr (Hdr_sz := sz)V4)[64--32]) ;
          st_trans := transition inl Parse5;
       |}
     | Parse45 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V4 <- EConcat (m := 24) (EHdr (sz := sz)Scratch40) ((EHdr (sz := sz)V4)[64--40]) ;
+          V4 <- EConcat (m := 24) (EHdr (Hdr_sz := sz)Scratch40) ((EHdr (Hdr_sz := sz)V4)[64--40]) ;
          st_trans := transition inl Parse5;
       |}
     | Parse46 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V4 <- EConcat (m := 16) (EHdr (sz := sz)Scratch48) ((EHdr (sz := sz)V4)[64--48]) ;
+          V4 <- EConcat (m := 16) (EHdr (Hdr_sz := sz)Scratch48) ((EHdr (Hdr_sz := sz)V4)[64--48]) ;
          st_trans := transition inl Parse5;
       |}
     | Parse47 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V4 <- EConcat (m := 8) (EHdr (sz := sz)Scratch56) ((EHdr (sz := sz)V4)[64--56]) ;
+          V4 <- EConcat (m := 8) (EHdr (Hdr_sz := sz)Scratch56) ((EHdr (Hdr_sz := sz)V4)[64--56]) ;
          st_trans := transition inl Parse5;
       |}
     | Parse48 =>
@@ -538,7 +538,7 @@ Module IPOptionsRef10.
       {| st_op :=
           extract(T5) ;;
           extract(L5) ;
-         st_trans := transition select (| EHdr (sz := sz)T5, EHdr (sz := sz)L5 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz)T5, EHdr (Hdr_sz := sz)L5 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse51 ;;;
@@ -555,43 +555,43 @@ Module IPOptionsRef10.
     | Parse51 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V5 <- EConcat (m := 56) (EHdr (sz := sz)Scratch8) ((EHdr (sz := sz)V5)[64--8]) ;
+          V5 <- EConcat (m := 56) (EHdr (Hdr_sz := sz)Scratch8) ((EHdr (Hdr_sz := sz)V5)[64--8]) ;
          st_trans := transition inl Parse6;
       |}
     | Parse52 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V5 <- EConcat (m := 48) (EHdr (sz := sz)Scratch16) ((EHdr (sz := sz)V5)[64--16]) ;
+          V5 <- EConcat (m := 48) (EHdr (Hdr_sz := sz)Scratch16) ((EHdr (Hdr_sz := sz)V5)[64--16]) ;
          st_trans := transition inl Parse6;
       |}
     | Parse53 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V5 <- EConcat (m := 40) (EHdr (sz := sz)Scratch24) ((EHdr (sz := sz)V5)[64--24]) ;
+          V5 <- EConcat (m := 40) (EHdr (Hdr_sz := sz)Scratch24) ((EHdr (Hdr_sz := sz)V5)[64--24]) ;
          st_trans := transition inl Parse6;
       |}
     | Parse54 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V5 <- EConcat (m := 32) (EHdr (sz := sz)Scratch32) ((EHdr (sz := sz)V5)[64--32]) ;
+          V5 <- EConcat (m := 32) (EHdr (Hdr_sz := sz)Scratch32) ((EHdr (Hdr_sz := sz)V5)[64--32]) ;
          st_trans := transition inl Parse6;
       |}
     | Parse55 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V5 <- EConcat (m := 24) (EHdr (sz := sz)Scratch40) ((EHdr (sz := sz)V5)[64--40]) ;
+          V5 <- EConcat (m := 24) (EHdr (Hdr_sz := sz)Scratch40) ((EHdr (Hdr_sz := sz)V5)[64--40]) ;
          st_trans := transition inl Parse6;
       |}
     | Parse56 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V5 <- EConcat (m := 16) (EHdr (sz := sz)Scratch48) ((EHdr (sz := sz)V5)[64--48]) ;
+          V5 <- EConcat (m := 16) (EHdr (Hdr_sz := sz)Scratch48) ((EHdr (Hdr_sz := sz)V5)[64--48]) ;
          st_trans := transition inl Parse6;
       |}
     | Parse57 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V5 <- EConcat (m := 8) (EHdr (sz := sz)Scratch56) ((EHdr (sz := sz)V5)[64--56]) ;
+          V5 <- EConcat (m := 8) (EHdr (Hdr_sz := sz)Scratch56) ((EHdr (Hdr_sz := sz)V5)[64--56]) ;
          st_trans := transition inl Parse6;
       |}
     | Parse58 =>
@@ -604,7 +604,7 @@ Module IPOptionsRef10.
       {| st_op :=
           extract(T6) ;;
           extract(L6) ;
-         st_trans := transition select (| EHdr (sz := sz)T6, EHdr (sz := sz)L6 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz)T6, EHdr (Hdr_sz := sz)L6 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse61 ;;;
@@ -621,43 +621,43 @@ Module IPOptionsRef10.
     | Parse61 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V6 <- EConcat (m := 56) (EHdr (sz := sz)Scratch8) ((EHdr (sz := sz)V6)[64--8]) ;
+          V6 <- EConcat (m := 56) (EHdr (Hdr_sz := sz)Scratch8) ((EHdr (Hdr_sz := sz)V6)[64--8]) ;
          st_trans := transition inl Parse7;
       |}
     | Parse62 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V6 <- EConcat (m := 48) (EHdr (sz := sz)Scratch16) ((EHdr (sz := sz)V6)[64--16]) ;
+          V6 <- EConcat (m := 48) (EHdr (Hdr_sz := sz)Scratch16) ((EHdr (Hdr_sz := sz)V6)[64--16]) ;
          st_trans := transition inl Parse7;
       |}
     | Parse63 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V6 <- EConcat (m := 40) (EHdr (sz := sz)Scratch24) ((EHdr (sz := sz)V6)[64--24]) ;
+          V6 <- EConcat (m := 40) (EHdr (Hdr_sz := sz)Scratch24) ((EHdr (Hdr_sz := sz)V6)[64--24]) ;
          st_trans := transition inl Parse7;
       |}
     | Parse64 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V6 <- EConcat (m := 32) (EHdr (sz := sz)Scratch32) ((EHdr (sz := sz)V6)[64--32]) ;
+          V6 <- EConcat (m := 32) (EHdr (Hdr_sz := sz)Scratch32) ((EHdr (Hdr_sz := sz)V6)[64--32]) ;
          st_trans := transition inl Parse7;
       |}
     | Parse65 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V6 <- EConcat (m := 24) (EHdr (sz := sz)Scratch40) ((EHdr (sz := sz)V6)[64--40]) ;
+          V6 <- EConcat (m := 24) (EHdr (Hdr_sz := sz)Scratch40) ((EHdr (Hdr_sz := sz)V6)[64--40]) ;
          st_trans := transition inl Parse7;
       |}
     | Parse66 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V6 <- EConcat (m := 16) (EHdr (sz := sz)Scratch48) ((EHdr (sz := sz)V6)[64--48]) ;
+          V6 <- EConcat (m := 16) (EHdr (Hdr_sz := sz)Scratch48) ((EHdr (Hdr_sz := sz)V6)[64--48]) ;
          st_trans := transition inl Parse7;
       |}
     | Parse67 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V6 <- EConcat (m := 8) (EHdr (sz := sz)Scratch56) ((EHdr (sz := sz)V6)[64--56]) ;
+          V6 <- EConcat (m := 8) (EHdr (Hdr_sz := sz)Scratch56) ((EHdr (Hdr_sz := sz)V6)[64--56]) ;
          st_trans := transition inl Parse7;
       |}
     | Parse68 =>
@@ -670,7 +670,7 @@ Module IPOptionsRef10.
       {| st_op :=
           extract(T7) ;;
           extract(L7) ;
-         st_trans := transition select (| EHdr (sz := sz)T7, EHdr (sz := sz)L7 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz)T7, EHdr (Hdr_sz := sz)L7 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse71 ;;;
@@ -687,43 +687,43 @@ Module IPOptionsRef10.
     | Parse71 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V7 <- EConcat (m := 56) (EHdr (sz := sz)Scratch8) ((EHdr (sz := sz)V7)[64--8]) ;
+          V7 <- EConcat (m := 56) (EHdr (Hdr_sz := sz)Scratch8) ((EHdr (Hdr_sz := sz)V7)[64--8]) ;
          st_trans := transition inl Parse8;
       |}
     | Parse72 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V7 <- EConcat (m := 48) (EHdr (sz := sz)Scratch16) ((EHdr (sz := sz)V7)[64--16]) ;
+          V7 <- EConcat (m := 48) (EHdr (Hdr_sz := sz)Scratch16) ((EHdr (Hdr_sz := sz)V7)[64--16]) ;
          st_trans := transition inl Parse8;
       |}
     | Parse73 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V7 <- EConcat (m := 40) (EHdr (sz := sz)Scratch24) ((EHdr (sz := sz)V7)[64--24]) ;
+          V7 <- EConcat (m := 40) (EHdr (Hdr_sz := sz)Scratch24) ((EHdr (Hdr_sz := sz)V7)[64--24]) ;
          st_trans := transition inl Parse8;
       |}
     | Parse74 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V7 <- EConcat (m := 32) (EHdr (sz := sz)Scratch32) ((EHdr (sz := sz)V7)[64--32]) ;
+          V7 <- EConcat (m := 32) (EHdr (Hdr_sz := sz)Scratch32) ((EHdr (Hdr_sz := sz)V7)[64--32]) ;
          st_trans := transition inl Parse8;
       |}
     | Parse75 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V7 <- EConcat (m := 24) (EHdr (sz := sz)Scratch40) ((EHdr (sz := sz)V7)[64--40]) ;
+          V7 <- EConcat (m := 24) (EHdr (Hdr_sz := sz)Scratch40) ((EHdr (Hdr_sz := sz)V7)[64--40]) ;
          st_trans := transition inl Parse8;
       |}
     | Parse76 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V7 <- EConcat (m := 16) (EHdr (sz := sz)Scratch48) ((EHdr (sz := sz)V7)[64--48]) ;
+          V7 <- EConcat (m := 16) (EHdr (Hdr_sz := sz)Scratch48) ((EHdr (Hdr_sz := sz)V7)[64--48]) ;
          st_trans := transition inl Parse8;
       |}
     | Parse77 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V7 <- EConcat (m := 8) (EHdr (sz := sz)Scratch56) ((EHdr (sz := sz)V7)[64--56]) ;
+          V7 <- EConcat (m := 8) (EHdr (Hdr_sz := sz)Scratch56) ((EHdr (Hdr_sz := sz)V7)[64--56]) ;
          st_trans := transition inl Parse8;
       |}
     | Parse78 =>
@@ -736,7 +736,7 @@ Module IPOptionsRef10.
       {| st_op :=
           extract(T8) ;;
           extract(L8) ;
-         st_trans := transition select (| EHdr (sz := sz)T8, EHdr (sz := sz)L8 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz)T8, EHdr (Hdr_sz := sz)L8 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse81 ;;;
@@ -753,43 +753,43 @@ Module IPOptionsRef10.
     | Parse81 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V8 <- EConcat (m := 56) (EHdr (sz := sz)Scratch8) ((EHdr (sz := sz)V8)[64--8]) ;
+          V8 <- EConcat (m := 56) (EHdr (Hdr_sz := sz)Scratch8) ((EHdr (Hdr_sz := sz)V8)[64--8]) ;
          st_trans := transition inl Parse9;
       |}
     | Parse82 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V8 <- EConcat (m := 48) (EHdr (sz := sz)Scratch16) ((EHdr (sz := sz)V8)[64--16]) ;
+          V8 <- EConcat (m := 48) (EHdr (Hdr_sz := sz)Scratch16) ((EHdr (Hdr_sz := sz)V8)[64--16]) ;
          st_trans := transition inl Parse9;
       |}
     | Parse83 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V8 <- EConcat (m := 40) (EHdr (sz := sz)Scratch24) ((EHdr (sz := sz)V8)[64--24]) ;
+          V8 <- EConcat (m := 40) (EHdr (Hdr_sz := sz)Scratch24) ((EHdr (Hdr_sz := sz)V8)[64--24]) ;
          st_trans := transition inl Parse9;
       |}
     | Parse84 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V8 <- EConcat (m := 32) (EHdr (sz := sz)Scratch32) ((EHdr (sz := sz)V8)[64--32]) ;
+          V8 <- EConcat (m := 32) (EHdr (Hdr_sz := sz)Scratch32) ((EHdr (Hdr_sz := sz)V8)[64--32]) ;
          st_trans := transition inl Parse9;
       |}
     | Parse85 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V8 <- EConcat (m := 24) (EHdr (sz := sz)Scratch40) ((EHdr (sz := sz)V8)[64--40]) ;
+          V8 <- EConcat (m := 24) (EHdr (Hdr_sz := sz)Scratch40) ((EHdr (Hdr_sz := sz)V8)[64--40]) ;
          st_trans := transition inl Parse9;
       |}
     | Parse86 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V8 <- EConcat (m := 16) (EHdr (sz := sz)Scratch48) ((EHdr (sz := sz)V8)[64--48]) ;
+          V8 <- EConcat (m := 16) (EHdr (Hdr_sz := sz)Scratch48) ((EHdr (Hdr_sz := sz)V8)[64--48]) ;
          st_trans := transition inl Parse9;
       |}
     | Parse87 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V8 <- EConcat (m := 8) (EHdr (sz := sz)Scratch56) ((EHdr (sz := sz)V8)[64--56]) ;
+          V8 <- EConcat (m := 8) (EHdr (Hdr_sz := sz)Scratch56) ((EHdr (Hdr_sz := sz)V8)[64--56]) ;
          st_trans := transition inl Parse9;
       |}
     | Parse88 =>
@@ -802,7 +802,7 @@ Module IPOptionsRef10.
       {| st_op :=
           extract(T9) ;;
           extract(L9) ;
-         st_trans := transition select (| EHdr (sz := sz)T9, EHdr (sz := sz)L9 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz)T9, EHdr (Hdr_sz := sz)L9 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse91 ;;;
@@ -819,43 +819,43 @@ Module IPOptionsRef10.
     | Parse91 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V9 <- EConcat (m := 56) (EHdr (sz := sz)Scratch8) ((EHdr (sz := sz)V9)[64--8]) ;
+          V9 <- EConcat (m := 56) (EHdr (Hdr_sz := sz)Scratch8) ((EHdr (Hdr_sz := sz)V9)[64--8]) ;
          st_trans := transition accept;
       |}
     | Parse92 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V9 <- EConcat (m := 48) (EHdr (sz := sz)Scratch16) ((EHdr (sz := sz)V9)[64--16]) ;
+          V9 <- EConcat (m := 48) (EHdr (Hdr_sz := sz)Scratch16) ((EHdr (Hdr_sz := sz)V9)[64--16]) ;
          st_trans := transition accept;
       |}
     | Parse93 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V9 <- EConcat (m := 40) (EHdr (sz := sz)Scratch24) ((EHdr (sz := sz)V9)[64--24]) ;
+          V9 <- EConcat (m := 40) (EHdr (Hdr_sz := sz)Scratch24) ((EHdr (Hdr_sz := sz)V9)[64--24]) ;
          st_trans := transition accept;
       |}
     | Parse94 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V9 <- EConcat (m := 32) (EHdr (sz := sz)Scratch32) ((EHdr (sz := sz)V9)[64--32]) ;
+          V9 <- EConcat (m := 32) (EHdr (Hdr_sz := sz)Scratch32) ((EHdr (Hdr_sz := sz)V9)[64--32]) ;
          st_trans := transition accept;
       |}
     | Parse95 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V9 <- EConcat (m := 24) (EHdr (sz := sz)Scratch40) ((EHdr (sz := sz)V9)[64--40]) ;
+          V9 <- EConcat (m := 24) (EHdr (Hdr_sz := sz)Scratch40) ((EHdr (Hdr_sz := sz)V9)[64--40]) ;
          st_trans := transition accept;
       |}
     | Parse96 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V9 <- EConcat (m := 16) (EHdr (sz := sz)Scratch48) ((EHdr (sz := sz)V9)[64--48]) ;
+          V9 <- EConcat (m := 16) (EHdr (Hdr_sz := sz)Scratch48) ((EHdr (Hdr_sz := sz)V9)[64--48]) ;
          st_trans := transition accept;
       |}
     | Parse97 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V9 <- EConcat (m := 8) (EHdr (sz := sz)Scratch56) ((EHdr (sz := sz)V9)[64--56]) ;
+          V9 <- EConcat (m := 8) (EHdr (Hdr_sz := sz)Scratch56) ((EHdr (Hdr_sz := sz)V9)[64--56]) ;
          st_trans := transition accept;
       |}
     | Parse98 =>
@@ -993,7 +993,7 @@ Module IPOptionsRef5.
       {| st_op :=
           extract(T0) ;;
           extract(L0) ;
-         st_trans := transition select (| EHdr (sz := sz) T0, EHdr (sz := sz) L0 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T0, EHdr (Hdr_sz := sz) L0 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse01 ;;;
@@ -1010,43 +1010,43 @@ Module IPOptionsRef5.
     | Parse01 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V0 <- EConcat (m := 56) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V0)[64--8]) ;
+          V0 <- EConcat (m := 56) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V0)[64--8]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse02 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V0 <- EConcat (m := 48) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V0)[64--16]) ;
+          V0 <- EConcat (m := 48) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V0)[64--16]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse03 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V0 <- EConcat (m := 40) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V0)[64--24]) ;
+          V0 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V0)[64--24]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse04 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V0 <- EConcat (m := 32) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V0)[64--32]) ;
+          V0 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V0)[64--32]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse05 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V0 <- EConcat (m := 24) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V0)[64--40]) ;
+          V0 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V0)[64--40]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse06 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V0 <- EConcat (m := 16) (EHdr (sz := sz) Scratch48) ((EHdr (sz := sz) V0)[64--48]) ;
+          V0 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch48) ((EHdr (Hdr_sz := sz) V0)[64--48]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse07 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V0 <- EConcat (m := 8) (EHdr (sz := sz) Scratch56) ((EHdr (sz := sz) V0)[64--56]) ;
+          V0 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch56) ((EHdr (Hdr_sz := sz) V0)[64--56]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse08 =>
@@ -1059,7 +1059,7 @@ Module IPOptionsRef5.
       {| st_op :=
           extract(T1) ;;
           extract(L1) ;
-         st_trans := transition select (| EHdr (sz := sz) T1, EHdr (sz := sz) L1 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T1, EHdr (Hdr_sz := sz) L1 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse11 ;;;
@@ -1076,43 +1076,43 @@ Module IPOptionsRef5.
     | Parse11 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 56) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V1)[64--8]) ;
+          V1 <- EConcat (m := 56) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V1)[64--8]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse12 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 48) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V1)[64--16]) ;
+          V1 <- EConcat (m := 48) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V1)[64--16]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse13 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V1 <- EConcat (m := 40) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V1)[64--24]) ;
+          V1 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V1)[64--24]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse14 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V1 <- EConcat (m := 32) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V1)[64--32]) ;
+          V1 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V1)[64--32]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse15 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V1 <- EConcat (m := 24) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V1)[64--40]) ;
+          V1 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V1)[64--40]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse16 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V1 <- EConcat (m := 16) (EHdr (sz := sz) Scratch48) ((EHdr (sz := sz) V1)[64--48]) ;
+          V1 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch48) ((EHdr (Hdr_sz := sz) V1)[64--48]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse17 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V1 <- EConcat (m := 8) (EHdr (sz := sz) Scratch56) ((EHdr (sz := sz) V1)[64--56]) ;
+          V1 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch56) ((EHdr (Hdr_sz := sz) V1)[64--56]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse18 =>
@@ -1125,7 +1125,7 @@ Module IPOptionsRef5.
       {| st_op :=
           extract(T2) ;;
           extract(L2) ;
-         st_trans := transition select (| EHdr (sz := sz) T2, EHdr (sz := sz) L2 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T2, EHdr (Hdr_sz := sz) L2 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse21 ;;;
@@ -1142,43 +1142,43 @@ Module IPOptionsRef5.
     | Parse21 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 56) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V2)[64--8]) ;
+          V1 <- EConcat (m := 56) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V2)[64--8]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse22 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V2 <- EConcat (m := 48) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V2)[64--16]) ;
+          V2 <- EConcat (m := 48) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V2)[64--16]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse23 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V2 <- EConcat (m := 40) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V2)[64--24]) ;
+          V2 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V2)[64--24]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse24 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V2 <- EConcat (m := 32) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V2)[64--32]) ;
+          V2 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V2)[64--32]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse25 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V2 <- EConcat (m := 24) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V2)[64--40]) ;
+          V2 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V2)[64--40]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse26 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V2 <- EConcat (m := 16) (EHdr (sz := sz) Scratch48) ((EHdr (sz := sz) V2)[64--48]) ;
+          V2 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch48) ((EHdr (Hdr_sz := sz) V2)[64--48]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse27 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V2 <- EConcat (m := 8) (EHdr (sz := sz) Scratch56) ((EHdr (sz := sz) V2)[64--56]) ;
+          V2 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch56) ((EHdr (Hdr_sz := sz) V2)[64--56]) ;
          st_trans := transition inl Parse3;
       |}
     | Parse28 =>
@@ -1191,7 +1191,7 @@ Module IPOptionsRef5.
       {| st_op :=
           extract(T3) ;;
           extract(L3) ;
-         st_trans := transition select (| EHdr (sz := sz) T3, EHdr (sz := sz) L3 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T3, EHdr (Hdr_sz := sz) L3 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse31 ;;;
@@ -1208,43 +1208,43 @@ Module IPOptionsRef5.
     | Parse31 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V3 <- EConcat (m := 56) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V3)[64--8]) ;
+          V3 <- EConcat (m := 56) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V3)[64--8]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse32 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V3 <- EConcat (m := 48) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V3)[64--16]) ;
+          V3 <- EConcat (m := 48) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V3)[64--16]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse33 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V3 <- EConcat (m := 40) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V3)[64--24]) ;
+          V3 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V3)[64--24]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse34 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V3 <- EConcat (m := 32) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V3)[64--32]) ;
+          V3 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V3)[64--32]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse35 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V3 <- EConcat (m := 24) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V3)[64--40]) ;
+          V3 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V3)[64--40]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse36 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V3 <- EConcat (m := 16) (EHdr (sz := sz) Scratch48) ((EHdr (sz := sz) V3)[64--48]) ;
+          V3 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch48) ((EHdr (Hdr_sz := sz) V3)[64--48]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse37 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V3 <- EConcat (m := 8) (EHdr (sz := sz) Scratch56) ((EHdr (sz := sz) V3)[64--56]) ;
+          V3 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch56) ((EHdr (Hdr_sz := sz) V3)[64--56]) ;
          st_trans := transition inl Parse4;
       |}
     | Parse38 =>
@@ -1257,7 +1257,7 @@ Module IPOptionsRef5.
       {| st_op :=
           extract(T4) ;;
           extract(L4) ;
-         st_trans := transition select (| EHdr (sz := sz) T4, EHdr (sz := sz) L4 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T4, EHdr (Hdr_sz := sz) L4 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse41 ;;;
@@ -1274,43 +1274,43 @@ Module IPOptionsRef5.
     | Parse41 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V4 <- EConcat (m := 56) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V4)[64--8]) ;
+          V4 <- EConcat (m := 56) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V4)[64--8]) ;
          st_trans := transition accept;
       |}
     | Parse42 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V4 <- EConcat (m := 48) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V4)[64--16]) ;
+          V4 <- EConcat (m := 48) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V4)[64--16]) ;
          st_trans := transition accept;
       |}
     | Parse43 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V4 <- EConcat (m := 40) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V4)[64--24]) ;
+          V4 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V4)[64--24]) ;
          st_trans := transition accept;
       |}
     | Parse44 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V4 <- EConcat (m := 32) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V4)[64--32]) ;
+          V4 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V4)[64--32]) ;
          st_trans := transition accept;
       |}
     | Parse45 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V4 <- EConcat (m := 24) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V4)[64--40]) ;
+          V4 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V4)[64--40]) ;
          st_trans := transition accept;
       |}
     | Parse46 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V4 <- EConcat (m := 16) (EHdr (sz := sz) Scratch48) ((EHdr (sz := sz) V4)[64--48]) ;
+          V4 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch48) ((EHdr (Hdr_sz := sz) V4)[64--48]) ;
          st_trans := transition accept;
       |}
     | Parse47 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V4 <- EConcat (m := 8) (EHdr (sz := sz) Scratch56) ((EHdr (sz := sz) V4)[64--56]) ;
+          V4 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch56) ((EHdr (Hdr_sz := sz) V4)[64--56]) ;
          st_trans := transition accept;
       |}
     | Parse48 =>
@@ -1407,7 +1407,7 @@ Module IPOptionsRef2.
       {| st_op :=
           extract(T0) ;;
           extract(L0) ;
-         st_trans := transition select (| EHdr (sz := sz) T0, EHdr (sz := sz) L0 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T0, EHdr (Hdr_sz := sz) L0 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse01 ;;;
@@ -1424,43 +1424,43 @@ Module IPOptionsRef2.
     | Parse01 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V0 <- EConcat (m := 56) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V0)[64--8]) ;
+          V0 <- EConcat (m := 56) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V0)[64--8]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse02 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V0 <- EConcat (m := 48) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V0)[64--16]) ;
+          V0 <- EConcat (m := 48) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V0)[64--16]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse03 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V0 <- EConcat (m := 40) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V0)[64--24]) ;
+          V0 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V0)[64--24]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse04 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V0 <- EConcat (m := 32) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V0)[64--32]) ;
+          V0 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V0)[64--32]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse05 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V0 <- EConcat (m := 24) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V0)[64--40]) ;
+          V0 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V0)[64--40]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse06 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V0 <- EConcat (m := 16) (EHdr (sz := sz) Scratch48) ((EHdr (sz := sz) V0)[64--48]) ;
+          V0 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch48) ((EHdr (Hdr_sz := sz) V0)[64--48]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse07 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V0 <- EConcat (m := 8) (EHdr (sz := sz) Scratch56) ((EHdr (sz := sz) V0)[64--56]) ;
+          V0 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch56) ((EHdr (Hdr_sz := sz) V0)[64--56]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse08 =>
@@ -1473,7 +1473,7 @@ Module IPOptionsRef2.
       {| st_op :=
           extract(T1) ;;
           extract(L1) ;
-         st_trans := transition select (| EHdr (sz := sz) T1, EHdr (sz := sz) L1 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T1, EHdr (Hdr_sz := sz) L1 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse11 ;;;
@@ -1490,43 +1490,43 @@ Module IPOptionsRef2.
     | Parse11 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 56) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V1)[64--8]) ;
+          V1 <- EConcat (m := 56) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V1)[64--8]) ;
          st_trans := transition accept;
       |}
     | Parse12 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 48) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V1)[64--16]) ;
+          V1 <- EConcat (m := 48) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V1)[64--16]) ;
          st_trans := transition accept;
       |}
     | Parse13 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V1 <- EConcat (m := 40) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V1)[64--24]) ;
+          V1 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V1)[64--24]) ;
          st_trans := transition accept;
       |}
     | Parse14 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V1 <- EConcat (m := 32) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V1)[64--32]) ;
+          V1 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V1)[64--32]) ;
          st_trans := transition accept;
       |}
     | Parse15 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V1 <- EConcat (m := 24) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V1)[64--40]) ;
+          V1 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V1)[64--40]) ;
          st_trans := transition accept;
       |}
     | Parse16 =>
       {| st_op :=
           extract(Scratch48) ;;
-          V1 <- EConcat (m := 16) (EHdr (sz := sz) Scratch48) ((EHdr (sz := sz) V1)[64--48]) ;
+          V1 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch48) ((EHdr (Hdr_sz := sz) V1)[64--48]) ;
          st_trans := transition accept;
       |}
     | Parse17 =>
       {| st_op :=
           extract(Scratch56) ;;
-          V1 <- EConcat (m := 8) (EHdr (sz := sz) Scratch56) ((EHdr (sz := sz) V1)[64--56]) ;
+          V1 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch56) ((EHdr (Hdr_sz := sz) V1)[64--56]) ;
          st_trans := transition accept;
       |}
     | Parse18 =>
@@ -1597,7 +1597,7 @@ Module IPOptions32.
       {| st_op :=
           extract(T0) ;;
           extract(L0) ;
-         st_trans := transition select (| EHdr (sz := sz) T0, EHdr (sz := sz) L0 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T0, EHdr (Hdr_sz := sz) L0 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse01 ;;;
@@ -1609,13 +1609,13 @@ Module IPOptions32.
     | Parse01 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V0 <- EConcat (m := 16) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V0)[24--8]) ;
+          V0 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V0)[24--8]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse02 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V0 <- EConcat (m := 8) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V0)[24--16]) ;
+          V0 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V0)[24--16]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse03 =>
@@ -1627,7 +1627,7 @@ Module IPOptions32.
       {| st_op :=
           extract(T1) ;;
           extract(L1) ;
-         st_trans := transition select (| EHdr (sz := sz) T1, EHdr (sz := sz) L1 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T1, EHdr (Hdr_sz := sz) L1 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse11 ;;;
@@ -1639,13 +1639,13 @@ Module IPOptions32.
     | Parse11 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 16) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V1)[24--8]) ;
+          V1 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V1)[24--8]) ;
          st_trans := transition accept;
       |}
     | Parse12 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 8) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V1)[24--16]) ;
+          V1 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V1)[24--16]) ;
          st_trans := transition accept;
       |}
     | Parse13 =>
@@ -1718,7 +1718,7 @@ Module IPOptionsSpec32.
       {| st_op :=
           extract(T0) ;;
           extract(L0) ;
-         st_trans := transition select (| EHdr (sz := sz) T0, EHdr (sz := sz) L0 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T0, EHdr (Hdr_sz := sz) L0 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|1|0|0, exact #b|0|0|0|0|0|0|1|0 |] ==> inl Parse0S ;;;
@@ -1752,7 +1752,7 @@ Module IPOptionsSpec32.
       {| st_op :=
           extract(T1) ;;
           extract(L1) ;
-         st_trans := transition select (| EHdr (sz := sz) T1, EHdr (sz := sz) L1 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T1, EHdr (Hdr_sz := sz) L1 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|1|0|0, exact #b|0|0|0|0|0|0|1|0 |] ==> inl Parse1S ;;;
@@ -1860,7 +1860,7 @@ Module IPOptionsRef62.
       {| st_op :=
           extract(T0) ;;
           extract(L0) ;
-         st_trans := transition select (| EHdr (sz := sz) T0, EHdr (sz := sz) L0 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T0, EHdr (Hdr_sz := sz) L0 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse01 ;;;
@@ -1875,31 +1875,31 @@ Module IPOptionsRef62.
     | Parse01 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V0 <- EConcat (m := 40) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V0)[48--8]) ;
+          V0 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V0)[48--8]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse02 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V0 <- EConcat (m := 32) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V0)[48--16]) ;
+          V0 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V0)[48--16]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse03 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V0 <- EConcat (m := 24) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V0)[48--24]) ;
+          V0 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V0)[48--24]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse04 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V0 <- EConcat (m := 16) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V0)[48--32]) ;
+          V0 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V0)[48--32]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse05 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V0 <- EConcat (m := 8) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V0)[48--40]) ;
+          V0 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V0)[48--40]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse06 =>
@@ -1912,7 +1912,7 @@ Module IPOptionsRef62.
       {| st_op :=
           extract(T1) ;;
           extract(L1) ;
-         st_trans := transition select (| EHdr (sz := sz) T1, EHdr (sz := sz) L1 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T1, EHdr (Hdr_sz := sz) L1 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse11 ;;;
@@ -1927,31 +1927,31 @@ Module IPOptionsRef62.
     | Parse11 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 40) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V1)[48--8]) ;
+          V1 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V1)[48--8]) ;
          st_trans := transition accept;
       |}
     | Parse12 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 32) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V1)[48--16]) ;
+          V1 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V1)[48--16]) ;
          st_trans := transition accept;
       |}
     | Parse13 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V1 <- EConcat (m := 24) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V1)[48--24]) ;
+          V1 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V1)[48--24]) ;
          st_trans := transition accept;
       |}
     | Parse14 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V1 <- EConcat (m := 16) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V1)[48--32]) ;
+          V1 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V1)[48--32]) ;
          st_trans := transition accept;
       |}
     | Parse15 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V1 <- EConcat (m := 8) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V1)[48--40]) ;
+          V1 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V1)[48--40]) ;
          st_trans := transition accept;
       |}
     | Parse16 =>
@@ -2049,7 +2049,7 @@ Module IPOptionsRef63.
       {| st_op :=
           extract(T0) ;;
           extract(L0) ;
-         st_trans := transition select (| EHdr (sz := sz) T0, EHdr (sz := sz) L0 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T0, EHdr (Hdr_sz := sz) L0 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse01 ;;;
@@ -2064,31 +2064,31 @@ Module IPOptionsRef63.
     | Parse01 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V0 <- EConcat (m := 40) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V0)[48--8]) ;
+          V0 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V0)[48--8]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse02 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V0 <- EConcat (m := 32) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V0)[48--16]) ;
+          V0 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V0)[48--16]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse03 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V0 <- EConcat (m := 24) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V0)[48--24]) ;
+          V0 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V0)[48--24]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse04 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V0 <- EConcat (m := 16) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V0)[48--32]) ;
+          V0 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V0)[48--32]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse05 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V0 <- EConcat (m := 8) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V0)[48--40]) ;
+          V0 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V0)[48--40]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse06 =>
@@ -2101,7 +2101,7 @@ Module IPOptionsRef63.
       {| st_op :=
           extract(T1) ;;
           extract(L1) ;
-         st_trans := transition select (| EHdr (sz := sz) T1, EHdr (sz := sz) L1 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T1, EHdr (Hdr_sz := sz) L1 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse11 ;;;
@@ -2116,31 +2116,31 @@ Module IPOptionsRef63.
     | Parse11 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 40) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V1)[48--8]) ;
+          V1 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V1)[48--8]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse12 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 32) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V1)[48--16]) ;
+          V1 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V1)[48--16]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse13 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V1 <- EConcat (m := 24) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V1)[48--24]) ;
+          V1 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V1)[48--24]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse14 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V1 <- EConcat (m := 16) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V1)[48--32]) ;
+          V1 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V1)[48--32]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse15 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V1 <- EConcat (m := 8) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V1)[48--40]) ;
+          V1 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V1)[48--40]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse16 =>
@@ -2153,7 +2153,7 @@ Module IPOptionsRef63.
       {| st_op :=
           extract(T2) ;;
           extract(L2) ;
-         st_trans := transition select (| EHdr (sz := sz) T2, EHdr (sz := sz) L2 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T2, EHdr (Hdr_sz := sz) L2 |) {{
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| *, exact #b|0|0|0|0|0|0|0|1 |] ==> inl Parse21 ;;;
@@ -2168,31 +2168,31 @@ Module IPOptionsRef63.
     | Parse21 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 40) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V2)[48--8]) ;
+          V1 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V2)[48--8]) ;
          st_trans := transition accept;
       |}
     | Parse22 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V2 <- EConcat (m := 32) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V2)[48--16]) ;
+          V2 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V2)[48--16]) ;
          st_trans := transition accept;
       |}
     | Parse23 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V2 <- EConcat (m := 24) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V2)[48--24]) ;
+          V2 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V2)[48--24]) ;
          st_trans := transition accept;
       |}
     | Parse24 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V2 <- EConcat (m := 16) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V2)[48--32]) ;
+          V2 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V2)[48--32]) ;
          st_trans := transition accept;
       |}
     | Parse25 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V2 <- EConcat (m := 8) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V2)[48--40]) ;
+          V2 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V2)[48--40]) ;
          st_trans := transition accept;
       |}
     | Parse26 =>

--- a/lib/Benchmarks/SelfComparison.v
+++ b/lib/Benchmarks/SelfComparison.v
@@ -62,7 +62,7 @@ Module ReadUndef.
     match s with
     | ParseEth =>
       {| st_op := extract(HdrEth);
-         st_trans := transition select (| (EHdr (sz := sz) HdrEth)[0 -- 0] |) {{
+         st_trans := transition select (| (EHdr (Hdr_sz := sz) HdrEth)[0 -- 0] |) {{
                                     [| exact #b|0 |] ==> inl DefaultVLAN ;;;
                                     [| exact #b|1 |] ==> inl ParseVLAN ;;;
                                     reject
@@ -83,7 +83,7 @@ Module ReadUndef.
       |}
     | ParseUDP =>
       {| st_op := extract(HdrUDP);
-         st_trans := transition select (| (EHdr (sz := sz) HdrVLAN)[3--0] |) {{
+         st_trans := transition select (| (EHdr (Hdr_sz := sz) HdrVLAN)[3--0] |) {{
                                     [| exact #b|1|1|1|1 |] ==> reject ;;;
                                     accept
                                 }}
@@ -137,7 +137,7 @@ Module ReadUndefIncorrect.
     match s with
     | ParseEth =>
       {| st_op := extract(HdrEth);
-         st_trans := transition select (| (EHdr (sz := sz) HdrEth)[0 -- 0] |) {{
+         st_trans := transition select (| (EHdr (Hdr_sz := sz) HdrEth)[0 -- 0] |) {{
                                     [| exact #b|0 |] ==> inl DefaultVLAN ;;;
                                     [| exact #b|1 |] ==> inl ParseVLAN ;;;
                                     reject
@@ -157,7 +157,7 @@ Module ReadUndefIncorrect.
       |}
     | ParseUDP =>
       {| st_op := extract(HdrUDP);
-         st_trans := transition select (| (EHdr (sz := sz) HdrVLAN)[3--0] |) {{
+         st_trans := transition select (| (EHdr (Hdr_sz := sz) HdrVLAN)[3--0] |) {{
                                     [| exact #b|1|1|1|1 |] ==> reject ;;;
                                     accept
                                 }}

--- a/lib/Benchmarks/ServiceProvider.v
+++ b/lib/Benchmarks/ServiceProvider.v
@@ -69,7 +69,7 @@ Module Plain.
     match s with
     | ParseEth =>
       {| st_op := extract(HdrEth);
-        st_trans := transition select (| (EHdr (sz := sz) HdrEth)[111--96] |)
+        st_trans := transition select (| (EHdr (Hdr_sz := sz) HdrEth)[111--96] |)
                                 {{ [| exact #b|1|0|0|0|1|0|0|0|0|1|0|0|0|1|1|1 |] ==> inl ParseMPLS ;;;
                                   [| exact #b|1|0|0|0|1|0|0|0|0|1|0|0|1|0|0|0 |] ==> inl ParseMPLS ;;;
                                   [| exact #b|0|0|0|0|1|0|0|0|0|0|0|0|0|0|0|0 |] ==> inl ParseEthv4 ;;;
@@ -195,7 +195,7 @@ Module Optimized.
   match s with
   | State_0 => {|
     st_op := extract(buf_112);
-    st_trans := transition select (| (EHdr (sz := sz) buf_112)[15 -- 15], (EHdr buf_112)[14 -- 14], (EHdr buf_112)[13 -- 13], (EHdr buf_112)[12 -- 12], (EHdr buf_112)[11 -- 11], (EHdr buf_112)[10 -- 10], (EHdr buf_112)[9 -- 9], (EHdr buf_112)[8 -- 8], (EHdr buf_112)[7 -- 7], (EHdr buf_112)[6 -- 6], (EHdr buf_112)[5 -- 5], (EHdr buf_112)[4 -- 4], (EHdr buf_112)[3 -- 3], (EHdr buf_112)[2 -- 2], (EHdr buf_112)[1 -- 1], (EHdr buf_112)[0 -- 0], (EHdr buf_112)[111 -- 111], (EHdr buf_112)[110 -- 110], (EHdr buf_112)[109 -- 109], (EHdr buf_112)[108 -- 108], (EHdr buf_112)[107 -- 107], (EHdr buf_112)[106 -- 106], (EHdr buf_112)[105 -- 105], (EHdr buf_112)[104 -- 104], (EHdr buf_112)[103 -- 103], (EHdr buf_112)[102 -- 102], (EHdr buf_112)[101 -- 101], (EHdr buf_112)[100 -- 100], (EHdr buf_112)[99 -- 99], (EHdr buf_112)[98 -- 98], (EHdr buf_112)[97 -- 97], (EHdr buf_112)[96 -- 96]|) {{
+    st_trans := transition select (| (EHdr (Hdr_sz := sz) buf_112)[15 -- 15], (EHdr buf_112)[14 -- 14], (EHdr buf_112)[13 -- 13], (EHdr buf_112)[12 -- 12], (EHdr buf_112)[11 -- 11], (EHdr buf_112)[10 -- 10], (EHdr buf_112)[9 -- 9], (EHdr buf_112)[8 -- 8], (EHdr buf_112)[7 -- 7], (EHdr buf_112)[6 -- 6], (EHdr buf_112)[5 -- 5], (EHdr buf_112)[4 -- 4], (EHdr buf_112)[3 -- 3], (EHdr buf_112)[2 -- 2], (EHdr buf_112)[1 -- 1], (EHdr buf_112)[0 -- 0], (EHdr buf_112)[111 -- 111], (EHdr buf_112)[110 -- 110], (EHdr buf_112)[109 -- 109], (EHdr buf_112)[108 -- 108], (EHdr buf_112)[107 -- 107], (EHdr buf_112)[106 -- 106], (EHdr buf_112)[105 -- 105], (EHdr buf_112)[104 -- 104], (EHdr buf_112)[103 -- 103], (EHdr buf_112)[102 -- 102], (EHdr buf_112)[101 -- 101], (EHdr buf_112)[100 -- 100], (EHdr buf_112)[99 -- 99], (EHdr buf_112)[98 -- 98], (EHdr buf_112)[97 -- 97], (EHdr buf_112)[96 -- 96]|) {{
       [| *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0 |] ==> inl State_1 ;;;
       [| *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|1, exact #b|0, exact #b|1, exact #b|1, exact #b|0, exact #b|1, exact #b|1, exact #b|1, exact #b|0, exact #b|1 |] ==> inl State_0_suff_1 ;;;
       [| *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|1, exact #b|1 |] ==> inl State_0_suff_2 ;;;
@@ -217,7 +217,7 @@ Module Optimized.
   |}
   | State_1 => {|
     st_op := extract(buf_16);
-    st_trans := transition select (| (EHdr (sz := sz) buf_16)[15 -- 15], (EHdr buf_16)[14 -- 14], (EHdr buf_16)[13 -- 13], (EHdr buf_16)[12 -- 12], (EHdr buf_16)[11 -- 11], (EHdr buf_16)[10 -- 10], (EHdr buf_16)[9 -- 9], (EHdr buf_16)[8 -- 8], (EHdr buf_16)[7 -- 7], (EHdr buf_16)[6 -- 6], (EHdr buf_16)[5 -- 5], (EHdr buf_16)[4 -- 4], (EHdr buf_16)[3 -- 3], (EHdr buf_16)[2 -- 2], (EHdr buf_16)[1 -- 1], (EHdr buf_16)[0 -- 0], (EHdr buf_16)[15 -- 15], (EHdr buf_16)[14 -- 14], (EHdr buf_16)[13 -- 13], (EHdr buf_16)[12 -- 12], (EHdr buf_16)[11 -- 11], (EHdr buf_16)[10 -- 10], (EHdr buf_16)[9 -- 9], (EHdr buf_16)[8 -- 8], (EHdr buf_16)[7 -- 7], (EHdr buf_16)[6 -- 6], (EHdr buf_16)[5 -- 5], (EHdr buf_16)[4 -- 4], (EHdr buf_16)[3 -- 3], (EHdr buf_16)[2 -- 2], (EHdr buf_16)[1 -- 1], (EHdr buf_16)[0 -- 0]|) {{
+    st_trans := transition select (| (EHdr (Hdr_sz := sz) buf_16)[15 -- 15], (EHdr buf_16)[14 -- 14], (EHdr buf_16)[13 -- 13], (EHdr buf_16)[12 -- 12], (EHdr buf_16)[11 -- 11], (EHdr buf_16)[10 -- 10], (EHdr buf_16)[9 -- 9], (EHdr buf_16)[8 -- 8], (EHdr buf_16)[7 -- 7], (EHdr buf_16)[6 -- 6], (EHdr buf_16)[5 -- 5], (EHdr buf_16)[4 -- 4], (EHdr buf_16)[3 -- 3], (EHdr buf_16)[2 -- 2], (EHdr buf_16)[1 -- 1], (EHdr buf_16)[0 -- 0], (EHdr buf_16)[15 -- 15], (EHdr buf_16)[14 -- 14], (EHdr buf_16)[13 -- 13], (EHdr buf_16)[12 -- 12], (EHdr buf_16)[11 -- 11], (EHdr buf_16)[10 -- 10], (EHdr buf_16)[9 -- 9], (EHdr buf_16)[8 -- 8], (EHdr buf_16)[7 -- 7], (EHdr buf_16)[6 -- 6], (EHdr buf_16)[5 -- 5], (EHdr buf_16)[4 -- 4], (EHdr buf_16)[3 -- 3], (EHdr buf_16)[2 -- 2], (EHdr buf_16)[1 -- 1], (EHdr buf_16)[0 -- 0]|) {{
       [| *, *, *, *, exact #b|0, exact #b|1, exact #b|0, exact #b|1, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, * |] ==> inl State_1_suff_0 ;;;
       [| *, *, *, *, exact #b|0, exact #b|1, exact #b|1, exact #b|0, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, * |] ==> inl State_1_suff_1 ;;;
       [| *, *, *, *, exact #b|0, exact #b|1, exact #b|1, exact #b|1, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, * |] ==> inl State_1_suff_2 ;;;
@@ -254,7 +254,7 @@ Module Optimized.
   |}
   | State_4 => {|
     st_op := extract(buf_16);
-    st_trans := transition select (| (EHdr (sz := sz) buf_16)[15--12], (EHdr buf_16)[8--8] |) {{
+    st_trans := transition select (| (EHdr (Hdr_sz := sz) buf_16)[15--12], (EHdr buf_16)[8--8] |) {{
       [| exact #b|0|1|0|0, exact #b|1 |] ==> inl State_1 ;;;
       [| exact #b|0|1|1|0, exact #b|1 |] ==> inl State_2 ;;;
       [| *, exact #b|0 |] ==> inl State_4_body ;;;
@@ -263,7 +263,7 @@ Module Optimized.
   |}
   | State_4_body => {|
     st_op := extract(buf_32);
-    st_trans := transition select (| (EHdr (sz := sz) buf_32)[31 -- 31], (EHdr buf_32)[30 -- 30], (EHdr buf_32)[29 -- 29], (EHdr buf_32)[28 -- 28], (EHdr buf_32)[27 -- 27], (EHdr buf_32)[26 -- 26], (EHdr buf_32)[25 -- 25], (EHdr buf_32)[24 -- 24], (EHdr buf_32)[23 -- 23], (EHdr buf_32)[22 -- 22], (EHdr buf_32)[21 -- 21], (EHdr buf_32)[20 -- 20], (EHdr buf_32)[19 -- 19], (EHdr buf_32)[18 -- 18], (EHdr buf_32)[17 -- 17], (EHdr buf_32)[16 -- 16]|) {{
+    st_trans := transition select (| (EHdr (Hdr_sz := sz) buf_32)[31 -- 31], (EHdr buf_32)[30 -- 30], (EHdr buf_32)[29 -- 29], (EHdr buf_32)[28 -- 28], (EHdr buf_32)[27 -- 27], (EHdr buf_32)[26 -- 26], (EHdr buf_32)[25 -- 25], (EHdr buf_32)[24 -- 24], (EHdr buf_32)[23 -- 23], (EHdr buf_32)[22 -- 22], (EHdr buf_32)[21 -- 21], (EHdr buf_32)[20 -- 20], (EHdr buf_32)[19 -- 19], (EHdr buf_32)[18 -- 18], (EHdr buf_32)[17 -- 17], (EHdr buf_32)[16 -- 16]|) {{
       [| *, *, *, *, *, *, *, exact #b|0, *, *, *, *, *, *, *, * |] ==> inl State_4_suff_0 ;;;
       reject
     }}

--- a/lib/Benchmarks/SimpleParsers.v
+++ b/lib/Benchmarks/SimpleParsers.v
@@ -183,7 +183,7 @@ Module TwoOnesBucket.
     | Start =>
       {| st_op :=
           extract(Val) ;;
-          Bits <- EConcat (m := 1) (EHdr Val) ((EHdr (sz := sz) Bits)[1--1]) ;
+          Bits <- EConcat (m := 1) (EHdr Val) ((EHdr (Hdr_sz := sz) Bits)[1--1]) ;
          st_trans := transition select (| EHdr Val |) {{
            [| exact #b|1 |] ==> inl Next ;;;
             @reject state
@@ -192,7 +192,7 @@ Module TwoOnesBucket.
     | Next =>
       {| st_op :=
           extract(Val) ;;
-          Bits <- EConcat (m := 1) (ESlice _ (EHdr (sz := sz) Bits) 0 0) (EHdr Val) ;
+          Bits <- EConcat (m := 1) (ESlice _ (EHdr (Hdr_sz := sz) Bits) 0 0) (EHdr Val) ;
          st_trans := transition select (| EHdr Val |) {{
            [| exact #b|1 |] ==> accept ;;;
             @reject state

--- a/lib/Benchmarks/SloppyStrict.v
+++ b/lib/Benchmarks/SloppyStrict.v
@@ -54,7 +54,7 @@ Module Sloppy.
     match s with
     | ParseEthernet =>
       {| st_op := extract(HdrEthernet) ;
-         st_trans := transition select (| ESlice _ (EHdr (sz := sz) HdrEthernet) 111 96 |) {{
+         st_trans := transition select (| ESlice _ (EHdr (Hdr_sz := sz) HdrEthernet) 111 96 |) {{
            [| hexact 0x86dd |] ==> inl ParseIPv6 ;;;
             inl ParseIPv4
          }}

--- a/lib/Benchmarks/SmallFilter.v
+++ b/lib/Benchmarks/SmallFilter.v
@@ -144,7 +144,7 @@ Module OneBit.
     match s with
     | Parse =>
       {| st_op := extract(Pref);
-         st_trans := transition select (| (EHdr (sz := sz) Pref)[0 -- 0] |) {{
+         st_trans := transition select (| (EHdr (Hdr_sz := sz) Pref)[0 -- 0] |) {{
            [| exact #b|1 |] ==> accept ;;;
             @reject state
          }}

--- a/lib/Benchmarks/TCAMSimple.v
+++ b/lib/Benchmarks/TCAMSimple.v
@@ -38,7 +38,7 @@ Module VerySimple.
     match s with
     | Ethernet => {|
       st_op := extract(H_Eth);
-      st_trans := transition select (| (EHdr (sz := sz) H_Eth)[111 -- 96] |) {{
+      st_trans := transition select (| (EHdr (Hdr_sz := sz) H_Eth)[111 -- 96] |) {{
         [| exact #b|0|0|0|0|1|0|0|0|0|0|0|0|0|0|0|0 |] ==> inl IPV4 ;;;
         [| exact #b|1|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0 |] ==> inl VLan1 ;;;
         accept
@@ -46,7 +46,7 @@ Module VerySimple.
     |}
     | VLan1 => {|
       st_op := extract(H_VLan);
-      st_trans := transition select (| (EHdr (sz := sz) H_VLan)[31 -- 16]|) {{
+      st_trans := transition select (| (EHdr (Hdr_sz := sz) H_VLan)[31 -- 16]|) {{
         [| exact #b|0|0|0|0|1|0|0|0|0|0|0|0|0|0|0|0 |] ==> inl IPV4 ;;;
         [| exact #b|1|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0 |] ==> inl VLan2 ;;;
         reject
@@ -54,7 +54,7 @@ Module VerySimple.
     |}
     | VLan2 => {|
       st_op := extract(H_VLan);
-      st_trans := transition select (| (EHdr (sz := sz) H_VLan)[31 -- 16]|) {{
+      st_trans := transition select (| (EHdr (Hdr_sz := sz) H_VLan)[31 -- 16]|) {{
         [| exact #b|0|0|0|0|1|0|0|0|0|0|0|0|0|0|0|0 |] ==> inl IPV4 ;;;
         accept
       }}
@@ -107,7 +107,7 @@ Definition states (s: state) :=
   match s with
   | State_0 => {|
     st_op := extract(buf_112);
-    st_trans := transition select (| (EHdr (sz := sz) buf_112)[15 -- 15], (EHdr buf_112)[14 -- 14], (EHdr buf_112)[13 -- 13], (EHdr buf_112)[12 -- 12], (EHdr buf_112)[11 -- 11], (EHdr buf_112)[10 -- 10], (EHdr buf_112)[9 -- 9], (EHdr buf_112)[8 -- 8], (EHdr buf_112)[7 -- 7], (EHdr buf_112)[6 -- 6], (EHdr buf_112)[5 -- 5], (EHdr buf_112)[4 -- 4], (EHdr buf_112)[3 -- 3], (EHdr buf_112)[2 -- 2], (EHdr buf_112)[1 -- 1], (EHdr buf_112)[0 -- 0], (EHdr buf_112)[111 -- 111], (EHdr buf_112)[110 -- 110], (EHdr buf_112)[109 -- 109], (EHdr buf_112)[108 -- 108], (EHdr buf_112)[107 -- 107], (EHdr buf_112)[106 -- 106], (EHdr buf_112)[105 -- 105], (EHdr buf_112)[104 -- 104], (EHdr buf_112)[103 -- 103], (EHdr buf_112)[102 -- 102], (EHdr buf_112)[101 -- 101], (EHdr buf_112)[100 -- 100], (EHdr buf_112)[99 -- 99], (EHdr buf_112)[98 -- 98], (EHdr buf_112)[97 -- 97], (EHdr buf_112)[96 -- 96]|) {{
+    st_trans := transition select (| (EHdr (Hdr_sz := sz) buf_112)[15 -- 15], (EHdr buf_112)[14 -- 14], (EHdr buf_112)[13 -- 13], (EHdr buf_112)[12 -- 12], (EHdr buf_112)[11 -- 11], (EHdr buf_112)[10 -- 10], (EHdr buf_112)[9 -- 9], (EHdr buf_112)[8 -- 8], (EHdr buf_112)[7 -- 7], (EHdr buf_112)[6 -- 6], (EHdr buf_112)[5 -- 5], (EHdr buf_112)[4 -- 4], (EHdr buf_112)[3 -- 3], (EHdr buf_112)[2 -- 2], (EHdr buf_112)[1 -- 1], (EHdr buf_112)[0 -- 0], (EHdr buf_112)[111 -- 111], (EHdr buf_112)[110 -- 110], (EHdr buf_112)[109 -- 109], (EHdr buf_112)[108 -- 108], (EHdr buf_112)[107 -- 107], (EHdr buf_112)[106 -- 106], (EHdr buf_112)[105 -- 105], (EHdr buf_112)[104 -- 104], (EHdr buf_112)[103 -- 103], (EHdr buf_112)[102 -- 102], (EHdr buf_112)[101 -- 101], (EHdr buf_112)[100 -- 100], (EHdr buf_112)[99 -- 99], (EHdr buf_112)[98 -- 98], (EHdr buf_112)[97 -- 97], (EHdr buf_112)[96 -- 96]|) {{
       [| *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0 |] ==> inl State_0_suff_0 ;;;
       [| *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0 |] ==> inl State_0_suff_1 ;;;
       [| *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, * |] ==> accept ;;;
@@ -124,7 +124,7 @@ Definition states (s: state) :=
   |}
   | State_1 => {|
     st_op := extract(buf_48);
-    st_trans := transition select (| (EHdr (sz := sz) buf_48)[15 -- 15], (EHdr buf_48)[14 -- 14], (EHdr buf_48)[13 -- 13], (EHdr buf_48)[12 -- 12], (EHdr buf_48)[11 -- 11], (EHdr buf_48)[10 -- 10], (EHdr buf_48)[9 -- 9], (EHdr buf_48)[8 -- 8], (EHdr buf_48)[7 -- 7], (EHdr buf_48)[6 -- 6], (EHdr buf_48)[5 -- 5], (EHdr buf_48)[4 -- 4], (EHdr buf_48)[3 -- 3], (EHdr buf_48)[2 -- 2], (EHdr buf_48)[1 -- 1], (EHdr buf_48)[0 -- 0], (EHdr buf_48)[47 -- 47], (EHdr buf_48)[46 -- 46], (EHdr buf_48)[45 -- 45], (EHdr buf_48)[44 -- 44], (EHdr buf_48)[43 -- 43], (EHdr buf_48)[42 -- 42], (EHdr buf_48)[41 -- 41], (EHdr buf_48)[40 -- 40], (EHdr buf_48)[39 -- 39], (EHdr buf_48)[38 -- 38], (EHdr buf_48)[37 -- 37], (EHdr buf_48)[36 -- 36], (EHdr buf_48)[35 -- 35], (EHdr buf_48)[34 -- 34], (EHdr buf_48)[33 -- 33], (EHdr buf_48)[32 -- 32]|) {{
+    st_trans := transition select (| (EHdr (Hdr_sz := sz) buf_48)[15 -- 15], (EHdr buf_48)[14 -- 14], (EHdr buf_48)[13 -- 13], (EHdr buf_48)[12 -- 12], (EHdr buf_48)[11 -- 11], (EHdr buf_48)[10 -- 10], (EHdr buf_48)[9 -- 9], (EHdr buf_48)[8 -- 8], (EHdr buf_48)[7 -- 7], (EHdr buf_48)[6 -- 6], (EHdr buf_48)[5 -- 5], (EHdr buf_48)[4 -- 4], (EHdr buf_48)[3 -- 3], (EHdr buf_48)[2 -- 2], (EHdr buf_48)[1 -- 1], (EHdr buf_48)[0 -- 0], (EHdr buf_48)[47 -- 47], (EHdr buf_48)[46 -- 46], (EHdr buf_48)[45 -- 45], (EHdr buf_48)[44 -- 44], (EHdr buf_48)[43 -- 43], (EHdr buf_48)[42 -- 42], (EHdr buf_48)[41 -- 41], (EHdr buf_48)[40 -- 40], (EHdr buf_48)[39 -- 39], (EHdr buf_48)[38 -- 38], (EHdr buf_48)[37 -- 37], (EHdr buf_48)[36 -- 36], (EHdr buf_48)[35 -- 35], (EHdr buf_48)[34 -- 34], (EHdr buf_48)[33 -- 33], (EHdr buf_48)[32 -- 32]|) {{
       [| exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, * |] ==> inl State_1_suff_0 ;;;
       [| exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0 |] ==> inl State_1_suff_1 ;;;
       [| exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|1, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, exact #b|0, *, *, *, *, *, *, *, *, *, *, *, *, *, *, *, * |] ==> accept ;;;

--- a/lib/Benchmarks/TLVSmall.v
+++ b/lib/Benchmarks/TLVSmall.v
@@ -80,13 +80,13 @@ Module TLVRefSmall.
     | Parse11 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 16) (EHdr Scratch8) ((EHdr (sz := sz) V1)[24--8]);
+          V1 <- EConcat (m := 16) (EHdr Scratch8) ((EHdr (Hdr_sz := sz) V1)[24--8]);
          st_trans := transition (inl Parse2)
       |}
     | Parse12 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 8) (EHdr Scratch16) ((EHdr (sz := sz) V1)[24--16]);
+          V1 <- EConcat (m := 8) (EHdr Scratch16) ((EHdr (Hdr_sz := sz) V1)[24--16]);
          st_trans := transition (inl Parse2)
       |}
     | Parse13 =>
@@ -110,13 +110,13 @@ Module TLVRefSmall.
     | Parse21 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 16) (EHdr Scratch8) ((EHdr (sz := sz) V2)[24--8]);
+          V1 <- EConcat (m := 16) (EHdr Scratch8) ((EHdr (Hdr_sz := sz) V2)[24--8]);
          st_trans := transition (inl Parse3)
       |}
     | Parse22 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 8) (EHdr Scratch16) ((EHdr (sz := sz) V2)[24--16]);
+          V1 <- EConcat (m := 8) (EHdr Scratch16) ((EHdr (Hdr_sz := sz) V2)[24--16]);
          st_trans := transition (inl Parse3)
       |}
     | Parse23 =>
@@ -140,13 +140,13 @@ Module TLVRefSmall.
     | Parse31 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 16) (EHdr Scratch8) ((EHdr (sz := sz) V3)[24--8]);
+          V1 <- EConcat (m := 16) (EHdr Scratch8) ((EHdr (Hdr_sz := sz) V3)[24--8]);
          st_trans := transition accept
       |}
     | Parse32 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 8) (EHdr Scratch16) ((EHdr (sz := sz) V3)[24--16]);
+          V1 <- EConcat (m := 8) (EHdr Scratch16) ((EHdr (Hdr_sz := sz) V3)[24--16]);
          st_trans := transition accept
       |}
     | Parse33 =>

--- a/lib/Benchmarks/Timestamp.v
+++ b/lib/Benchmarks/Timestamp.v
@@ -83,31 +83,31 @@ Module TimestampRefKeepSingle.
     | ParseValue1 =>
       {| st_op :=
           extract(Scratch8) ;;
-          Value <- EConcat (m := 40) (EHdr Scratch8) ((EHdr (sz := sz) Value)[48--8])  ;
+          Value <- EConcat (m := 40) (EHdr Scratch8) ((@EHdr _ sz Value)[48--8])  ;
         st_trans := transition accept
       |}
     | ParseValue2 =>
       {| st_op :=
           extract(Scratch16) ;;
-          Value <- EConcat (m := 32) (EHdr Scratch16) ((EHdr (sz := sz) Value)[48--16])  ;
+          Value <- EConcat (m := 32) (EHdr Scratch16) ((@EHdr _ sz Value)[48--16])  ;
         st_trans := transition accept
       |}
     | ParseValue3 =>
       {| st_op :=
           extract(Scratch24) ;;
-          Value <- EConcat (m := 24) (EHdr Scratch24) ((EHdr (sz := sz) Value)[48--24])  ;
+          Value <- EConcat (m := 24) (EHdr Scratch24) ((@EHdr _ sz Value)[48--24])  ;
         st_trans := transition accept
       |}
     | ParseValue4 =>
       {| st_op :=
           extract(Scratch32) ;;
-          Value <- EConcat (m := 16) (EHdr Scratch32) ((EHdr (sz := sz) Value)[48--32])  ;
+          Value <- EConcat (m := 16) (EHdr Scratch32) ((@EHdr _ sz Value)[48--32])  ;
         st_trans := transition accept
       |}
     | ParseValue5 =>
       {| st_op :=
           extract(Scratch40) ;;
-          Value <- EConcat (m := 8) (EHdr Scratch40) ((EHdr (sz := sz) Value)[48--40])  ;
+          Value <- EConcat (m := 8) (EHdr Scratch40) ((@EHdr _ sz Value)[48--40])  ;
         st_trans := transition accept
       |}
     | ParseValue6 =>
@@ -188,31 +188,31 @@ Module TimestampRefZeroSingle.
     | ParseValue1 =>
       {| st_op :=
           extract(Scratch8) ;;
-          Value <- EConcat (n := 8) (EHdr (sz := sz) Scratch8) (ELit _ (Ntuple.n_tuple_repeat 40 false))  ;
+          Value <- EConcat (n := 8) (EHdr (Hdr_sz := sz) Scratch8) (ELit _ (Ntuple.n_tuple_repeat 40 false))  ;
         st_trans := transition accept
       |}
     | ParseValue2 =>
       {| st_op :=
           extract(Scratch16) ;;
-          Value <- EConcat (n := 16) (EHdr (sz := sz) Scratch16) (ELit _ (Ntuple.n_tuple_repeat 32 false))  ;
+          Value <- EConcat (n := 16) (EHdr (Hdr_sz := sz) Scratch16) (ELit _ (Ntuple.n_tuple_repeat 32 false))  ;
         st_trans := transition accept
       |}
     | ParseValue3 =>
       {| st_op :=
           extract(Scratch24) ;;
-          Value <- EConcat (n := 24) (EHdr (sz := sz) Scratch24) (ELit _ (Ntuple.n_tuple_repeat 24 false))  ;
+          Value <- EConcat (n := 24) (EHdr (Hdr_sz := sz) Scratch24) (ELit _ (Ntuple.n_tuple_repeat 24 false))  ;
         st_trans := transition accept
       |}
     | ParseValue4 =>
       {| st_op :=
           extract(Scratch32) ;;
-          Value <- EConcat (n := 32) (EHdr (sz := sz) Scratch32) (ELit _ (Ntuple.n_tuple_repeat 16 false))  ;
+          Value <- EConcat (n := 32) (EHdr (Hdr_sz := sz) Scratch32) (ELit _ (Ntuple.n_tuple_repeat 16 false))  ;
         st_trans := transition accept
       |}
     | ParseValue5 =>
       {| st_op :=
           extract(Scratch40) ;;
-          Value <- EConcat (n := 40) (EHdr (sz := sz) Scratch40) (ELit _ (Ntuple.n_tuple_repeat 8 false))  ;
+          Value <- EConcat (n := 40) (EHdr (Hdr_sz := sz) Scratch40) (ELit _ (Ntuple.n_tuple_repeat 8 false))  ;
         st_trans := transition accept
       |}
     | ParseValue6 =>
@@ -397,13 +397,13 @@ Module TimestampRefSmall.
     | Parse1 =>
       {| st_op :=
           extract(Pref1) ;;
-          Timestamps <- EConcat (m := 16) (EHdr Pref1) ((EHdr (sz := sz) Timestamps)[24--8])  ;
+          Timestamps <- EConcat (m := 16) (EHdr Pref1) ((EHdr (Hdr_sz := sz) Timestamps)[24--8])  ;
          st_trans := transition accept
       |}
     | Parse2 =>
       {| st_op :=
           extract(Pref2) ;;
-          Timestamps <- EConcat (m := 8) (EHdr Pref2) ((EHdr (sz := sz) Timestamps)[24--16]) ;
+          Timestamps <- EConcat (m := 8) (EHdr Pref2) ((EHdr (Hdr_sz := sz) Timestamps)[24--16]) ;
          st_trans := transition accept
       |}
     | Parse3 =>
@@ -573,7 +573,7 @@ Module TimestampSpec2.
       {| st_op :=
           extract(T0) ;;
           extract(L0) ;
-         st_trans := transition select (| EHdr (sz := sz) T0, EHdr (sz := sz) L0 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T0, EHdr (Hdr_sz := sz) L0 |) {{
            [| exact #b|0|1|0|0|0|1|0|0, exact #b|0|0|0|0|0|1|1|0 |] ==> inl Parse0S;;;
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
@@ -589,31 +589,31 @@ Module TimestampSpec2.
     | Parse01 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V0 <- EConcat (m := 40) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V0)[48--8]) ;
+          V0 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V0)[48--8]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse02 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V0 <- EConcat (m := 32) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V0)[48--16]) ;
+          V0 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V0)[48--16]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse03 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V0 <- EConcat (m := 24) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V0)[48--24]) ;
+          V0 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V0)[48--24]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse04 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V0 <- EConcat (m := 16) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V0)[48--32]) ;
+          V0 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V0)[48--32]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse05 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V0 <- EConcat (m := 8) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V0)[48--40]) ;
+          V0 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V0)[48--40]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse06 =>
@@ -635,7 +635,7 @@ Module TimestampSpec2.
       {| st_op :=
           extract(T1) ;;
           extract(L1) ;
-         st_trans := transition select (| EHdr (sz := sz) T1, EHdr (sz := sz) L1 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T1, EHdr (Hdr_sz := sz) L1 |) {{
            [| exact #b|0|1|0|0|0|1|0|0, exact #b|0|0|0|0|0|1|1|0 |] ==> inl Parse1S;;;
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
@@ -651,31 +651,31 @@ Module TimestampSpec2.
     | Parse11 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 40) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V1)[48--8]) ;
+          V1 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V1)[48--8]) ;
          st_trans := transition accept;
       |}
     | Parse12 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 32) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V1)[48--16]) ;
+          V1 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V1)[48--16]) ;
          st_trans := transition accept;
       |}
     | Parse13 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V1 <- EConcat (m := 24) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V1)[48--24]) ;
+          V1 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V1)[48--24]) ;
          st_trans := transition accept;
       |}
     | Parse14 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V1 <- EConcat (m := 16) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V1)[48--32]) ;
+          V1 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V1)[48--32]) ;
          st_trans := transition accept;
       |}
     | Parse15 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V1 <- EConcat (m := 8) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V1)[48--40]) ;
+          V1 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V1)[48--40]) ;
          st_trans := transition accept;
       |}
     | Parse16 =>
@@ -797,7 +797,7 @@ Module TimestampSpec3.
       {| st_op :=
           extract(T0) ;;
           extract(L0) ;
-         st_trans := transition select (| EHdr (sz := sz) T0, EHdr (sz := sz) L0 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T0, EHdr (Hdr_sz := sz) L0 |) {{
            [| exact #b|0|1|0|0|0|1|0|0, exact #b|0|0|0|0|0|1|1|0 |] ==> inl Parse0S;;;
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
@@ -813,31 +813,31 @@ Module TimestampSpec3.
     | Parse01 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V0 <- EConcat (m := 40) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V0)[48--8]) ;
+          V0 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V0)[48--8]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse02 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V0 <- EConcat (m := 32) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V0)[48--16]) ;
+          V0 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V0)[48--16]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse03 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V0 <- EConcat (m := 24) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V0)[48--24]) ;
+          V0 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V0)[48--24]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse04 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V0 <- EConcat (m := 16) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V0)[48--32]) ;
+          V0 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V0)[48--32]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse05 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V0 <- EConcat (m := 8) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V0)[48--40]) ;
+          V0 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V0)[48--40]) ;
          st_trans := transition inl Parse1;
       |}
     | Parse06 =>
@@ -859,7 +859,7 @@ Module TimestampSpec3.
       {| st_op :=
           extract(T1) ;;
           extract(L1) ;
-         st_trans := transition select (| EHdr (sz := sz) T1, EHdr (sz := sz) L1 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T1, EHdr (Hdr_sz := sz) L1 |) {{
            [| exact #b|0|1|0|0|0|1|0|0, exact #b|0|0|0|0|0|1|1|0 |] ==> inl Parse1S;;;
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
@@ -875,31 +875,31 @@ Module TimestampSpec3.
     | Parse11 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 40) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V1)[48--8]) ;
+          V1 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V1)[48--8]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse12 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V1 <- EConcat (m := 32) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V1)[48--16]) ;
+          V1 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V1)[48--16]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse13 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V1 <- EConcat (m := 24) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V1)[48--24]) ;
+          V1 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V1)[48--24]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse14 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V1 <- EConcat (m := 16) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V1)[48--32]) ;
+          V1 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V1)[48--32]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse15 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V1 <- EConcat (m := 8) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V1)[48--40]) ;
+          V1 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V1)[48--40]) ;
          st_trans := transition inl Parse2;
       |}
     | Parse16 =>
@@ -920,7 +920,7 @@ Module TimestampSpec3.
       {| st_op :=
           extract(T2) ;;
           extract(L2) ;
-         st_trans := transition select (| EHdr (sz := sz) T2, EHdr (sz := sz) L2 |) {{
+         st_trans := transition select (| EHdr (Hdr_sz := sz) T2, EHdr (Hdr_sz := sz) L2 |) {{
            [| exact #b|0|1|0|0|0|1|0|0, exact #b|0|0|0|0|0|1|1|0 |] ==> inl Parse2S;;;
            [| exact #b|0|0|0|0|0|0|0|0, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
            [| exact #b|0|0|0|0|0|0|0|1, exact #b|0|0|0|0|0|0|0|0 |] ==> accept ;;;
@@ -936,31 +936,31 @@ Module TimestampSpec3.
     | Parse21 =>
       {| st_op :=
           extract(Scratch8) ;;
-          V1 <- EConcat (m := 40) (EHdr (sz := sz) Scratch8) ((EHdr (sz := sz) V2)[48--8]) ;
+          V1 <- EConcat (m := 40) (EHdr (Hdr_sz := sz) Scratch8) ((EHdr (Hdr_sz := sz) V2)[48--8]) ;
          st_trans := transition accept;
       |}
     | Parse22 =>
       {| st_op :=
           extract(Scratch16) ;;
-          V2 <- EConcat (m := 32) (EHdr (sz := sz) Scratch16) ((EHdr (sz := sz) V2)[48--16]) ;
+          V2 <- EConcat (m := 32) (EHdr (Hdr_sz := sz) Scratch16) ((EHdr (Hdr_sz := sz) V2)[48--16]) ;
          st_trans := transition accept;
       |}
     | Parse23 =>
       {| st_op :=
           extract(Scratch24) ;;
-          V2 <- EConcat (m := 24) (EHdr (sz := sz) Scratch24) ((EHdr (sz := sz) V2)[48--24]) ;
+          V2 <- EConcat (m := 24) (EHdr (Hdr_sz := sz) Scratch24) ((EHdr (Hdr_sz := sz) V2)[48--24]) ;
          st_trans := transition accept;
       |}
     | Parse24 =>
       {| st_op :=
           extract(Scratch32) ;;
-          V2 <- EConcat (m := 16) (EHdr (sz := sz) Scratch32) ((EHdr (sz := sz) V2)[48--32]) ;
+          V2 <- EConcat (m := 16) (EHdr (Hdr_sz := sz) Scratch32) ((EHdr (Hdr_sz := sz) V2)[48--32]) ;
          st_trans := transition accept;
       |}
     | Parse25 =>
       {| st_op :=
           extract(Scratch40) ;;
-          V2 <- EConcat (m := 8) (EHdr (sz := sz) Scratch40) ((EHdr (sz := sz) V2)[48--40]) ;
+          V2 <- EConcat (m := 8) (EHdr (Hdr_sz := sz) Scratch40) ((EHdr (Hdr_sz := sz) V2)[48--40]) ;
          st_trans := transition accept;
       |}
     | Parse26 =>

--- a/lib/BisimChecker.v
+++ b/lib/BisimChecker.v
@@ -38,26 +38,26 @@ Section BisimChecker.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
   Notation St := (St1 + St2)%type.
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
 
-  Definition sum_not_accept1 (a: P4A.t (St1 + St2) sz) (s: St1) : crel a :=
+  Definition sum_not_accept1 (a: P4A.t (St1 + St2) Hdr_sz) (s: St1) : crel a :=
     List.map (fun n =>
                 {| cr_st := {| cs_st1 := {| st_state := inl (inl s); st_buf_len := n |};
                                cs_st2 := {| st_state := inr true;    st_buf_len := 0 |} |};
                    cr_rel := BRFalse _ BCEmp |})
              (range (P4A.size a (inl s))).
 
-  Definition sum_not_accept2 (a: P4A.t (St1 + St2) sz) (s: St2) : crel a :=
+  Definition sum_not_accept2 (a: P4A.t (St1 + St2) Hdr_sz) (s: St2) : crel a :=
     List.map (fun n =>
                 {| cr_st := {| cs_st1 := {| st_state := inr true;    st_buf_len := 0 |};
                                cs_st2 := {| st_state := inl (inr s); st_buf_len := n |} |};
                    cr_rel := BRFalse _ BCEmp |})
              (range (P4A.size a (inr s))).
 
-  Definition sum_init_rel (a: P4A.t (St1 + St2) sz) : crel a :=
+  Definition sum_init_rel (a: P4A.t (St1 + St2) Hdr_sz) : crel a :=
     List.concat (List.map (sum_not_accept1 a) (enum St1)
                           ++ List.map (sum_not_accept2 a) (enum St2)).
 

--- a/lib/Bisimulations/WPLeaps.v
+++ b/lib/Bisimulations/WPLeaps.v
@@ -26,9 +26,9 @@ Section WPLeaps.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
 
   Variable (wp: conf_rel a ->
                 list (conf_rel a)).
@@ -91,39 +91,39 @@ Section WPLeaps.
     | S n => range n ++ [n]
     end.
 
-  Definition not_accept1 (a: P4A.t St sz) (s: St) : crel a :=
+  Definition not_accept1 (a: P4A.t St Hdr_sz) (s: St) : crel a :=
     List.map (fun n =>
                 {| cr_st := {| cs_st1 := {| st_state := inr true; st_buf_len := 0 |};
                                cs_st2 := {| st_state := inl s;    st_buf_len := n |} |};
                    cr_rel := BRFalse _ BCEmp |})
              (range (P4A.size a s)).
 
-  Definition not_accept2 (a: P4A.t St sz) (s: St) : crel a :=
+  Definition not_accept2 (a: P4A.t St Hdr_sz) (s: St) : crel a :=
     List.map (fun n =>
                 {| cr_st := {| cs_st1 := {| st_state := inl s;    st_buf_len := n |};
                                cs_st2 := {| st_state := inr true; st_buf_len := 0 |} |};
                    cr_rel := BRFalse _ BCEmp |})
              (range (P4A.size a s)).
 
-  Definition init_rel (a: P4A.t St sz) : crel a :=
+  Definition init_rel (a: P4A.t St Hdr_sz) : crel a :=
     List.concat (List.map (not_accept1 a) (enum St) ++
                           List.map (not_accept2 a) (enum St)).
 
-  Definition sum_not_accept1 (a: P4A.t (St1 + St2) sz) (s: St1) : crel a :=
+  Definition sum_not_accept1 (a: P4A.t (St1 + St2) Hdr_sz) (s: St1) : crel a :=
     List.map (fun n =>
                 {| cr_st := {| cs_st1 := {| st_state := inl (inl s); st_buf_len := n |};
                                cs_st2 := {| st_state := inr true;    st_buf_len := 0 |} |};
                    cr_rel := BRFalse _ BCEmp |})
              (range (P4A.size a (inl s))).
 
-  Definition sum_not_accept2 (a: P4A.t (St1 + St2) sz) (s: St2) : crel a :=
+  Definition sum_not_accept2 (a: P4A.t (St1 + St2) Hdr_sz) (s: St2) : crel a :=
     List.map (fun n =>
                 {| cr_st := {| cs_st1 := {| st_state := inr true;    st_buf_len := 0 |};
                                cs_st2 := {| st_state := inl (inr s); st_buf_len := n |} |};
                    cr_rel := BRFalse _ BCEmp |})
              (range (P4A.size a (inr s))).
 
-  Definition sum_init_rel (a: P4A.t (St1 + St2) sz) : crel a :=
+  Definition sum_init_rel (a: P4A.t (St1 + St2) Hdr_sz) : crel a :=
     List.concat (List.map (sum_not_accept1 a) (enum St1)
                           ++ List.map (sum_not_accept2 a) (enum St2)).
   Notation "ctx , ⟨ s1 , n1 ⟩ ⟨ s2 , n2 ⟩ ⊢ b" :=
@@ -194,8 +194,8 @@ Section WPLeaps.
       ctopbdd (wp C).
 End WPLeaps.
 
-Arguments pre_bisimulation {St1 St2 Hdr equiv2 Hdr_eq_dec Hdr_finite sz} a wp.
-Arguments ctopbdd {St1 St2 Hdr equiv2 Hdr_eq_dec Hdr_finite sz} a top C.
-Arguments topbdd {St1 St2 Hdr equiv2 Hdr_eq_dec Hdr_finite sz} a top C.
-Arguments safe_wp_1bit {St1 St2 Hdr equiv2 Hdr_eq_dec Hdr_finite sz} a wp top.
-Arguments wp_bdd {St1 St2 Hdr equiv2 Hdr_eq_dec Hdr_finite sz} a wp top.
+Arguments pre_bisimulation {St1 St2 Hdr equiv2 Hdr_eq_dec Hdr_finite Hdr_sz} a wp.
+Arguments ctopbdd {St1 St2 Hdr equiv2 Hdr_eq_dec Hdr_finite Hdr_sz} a top C.
+Arguments topbdd {St1 St2 Hdr equiv2 Hdr_eq_dec Hdr_finite Hdr_sz} a top C.
+Arguments safe_wp_1bit {St1 St2 Hdr equiv2 Hdr_eq_dec Hdr_finite Hdr_sz} a wp top.
+Arguments wp_bdd {St1 St2 Hdr equiv2 Hdr_eq_dec Hdr_finite Hdr_sz} a wp top.

--- a/lib/Bisimulations/WPLeapsProofs.v
+++ b/lib/Bisimulations/WPLeapsProofs.v
@@ -38,9 +38,9 @@ Section WPLeapsProofs.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
 
   Variable (s1: St1).
   Variable (s2: St2).
@@ -92,7 +92,7 @@ Section WPLeapsProofs.
   Qed.
 
   Lemma not_equally_accepting_correct q1 q2:
-    not_equally_accepting St1 St2 Hdr sz a (conf_to_state_template q1,
+    not_equally_accepting St1 St2 Hdr Hdr_sz a (conf_to_state_template q1,
                                             conf_to_state_template q2) = false ->
     accepting q1 <-> accepting q2.
   Proof.

--- a/lib/CompileConfRel.v
+++ b/lib/CompileConfRel.v
@@ -19,9 +19,9 @@ Section CompileConfRel.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
 
   Notation conf := (configuration (P4A.interp a)).
 
@@ -32,7 +32,7 @@ Section CompileConfRel.
     end.
 
   Definition be_sort {c} {b1 b2: nat} (e: bit_expr Hdr c) : sorts :=
-    Bits (be_size sz b1 b2 e).
+    Bits (be_size Hdr_sz b1 b2 e).
 
   Equations compile_var {c: bctx} (x: bvar c) : var (sig a) (compile_bctx c) (Bits (check_bvar x)) :=
     { compile_var (BVarTop c size) :=
@@ -86,7 +86,7 @@ Section CompileConfRel.
     { compile_store_rel q BRTrue := FTrue;
       compile_store_rel q BRFalse := FFalse;
       compile_store_rel q (BREq e1 e2) :=
-        match eq_dec (be_size sz b1 b2 e1) (be_size sz b1 b2 e2) with
+        match eq_dec (be_size Hdr_sz b1 b2 e1) (be_size Hdr_sz b1 b2 e2) with
         | left Heq =>
           FEq (eq_rect _ (fun n => tm (sig a) _ (Bits n))
                        (compile_bit_expr q e1) _ Heq)

--- a/lib/CompileConfRelSimplified.v
+++ b/lib/CompileConfRelSimplified.v
@@ -20,20 +20,20 @@ Section CompileConfRelSimplified.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
 
-  Fixpoint compile_bctx (b: bctx): ctx (sig sz) :=
+  Fixpoint compile_bctx (b: bctx): ctx (sig Hdr_sz) :=
     match b with
     | BCEmp => CEmp _
     | BCSnoc b size => CSnoc _ (compile_bctx b) (Bits size)
     end.
 
   Definition be_sort {c} b1 b2 (e: bit_expr Hdr c) : sorts :=
-    Bits (be_size sz b1 b2 e).
+    Bits (be_size Hdr_sz b1 b2 e).
 
-  Equations compile_var {c: bctx} (x: bvar c) : var (sig sz) (compile_bctx c) (Bits (check_bvar x)) :=
+  Equations compile_var {c: bctx} (x: bvar c) : var (sig Hdr_sz) (compile_bctx c) (Bits (check_bvar x)) :=
     { compile_var (BVarTop c size) :=
         VHere _ (compile_bctx c) (Bits (check_bvar (BVarTop c size)));
       compile_var (BVarRest y) :=
@@ -69,26 +69,26 @@ Section CompileConfRelSimplified.
   Qed.
 
   Definition outer_ctx b1 b2 :=
-    CSnoc (sig sz) (
-      CSnoc (sig sz) (
-        CSnoc (sig sz) (
-          CSnoc (sig sz) (CEmp (sig sz)) Store
+    CSnoc (sig Hdr_sz) (
+      CSnoc (sig Hdr_sz) (
+        CSnoc (sig Hdr_sz) (
+          CSnoc (sig Hdr_sz) (CEmp (sig Hdr_sz)) Store
         ) Store
       ) (Bits b2)
     ) (Bits b1).
 
-  Definition var_buf1 b1 b2 : var (sig sz) (outer_ctx b1 b2) (Bits b1) :=
-    VHere (sig sz) _ _.
+  Definition var_buf1 b1 b2 : var (sig Hdr_sz) (outer_ctx b1 b2) (Bits b1) :=
+    VHere (sig Hdr_sz) _ _.
 
-  Definition var_buf2 b1 b2 : var (sig sz) (outer_ctx b1 b2) (Bits b2) :=
-    VThere (sig sz) _ _ _ (VHere (sig sz) _ _).
+  Definition var_buf2 b1 b2 : var (sig Hdr_sz) (outer_ctx b1 b2) (Bits b2) :=
+    VThere (sig Hdr_sz) _ _ _ (VHere (sig Hdr_sz) _ _).
 
-  Definition var_store1 b1 b2 : var (sig sz) (outer_ctx b1 b2) Store :=
-    VThere (sig sz) _ _ _ (VThere (sig sz) _ _ _ (VHere (sig sz) _ _)).
+  Definition var_store1 b1 b2 : var (sig Hdr_sz) (outer_ctx b1 b2) Store :=
+    VThere (sig Hdr_sz) _ _ _ (VThere (sig Hdr_sz) _ _ _ (VHere (sig Hdr_sz) _ _)).
 
-  Definition var_store2 b1 b2 : var (sig sz) (outer_ctx b1 b2) Store :=
-    VThere (sig sz) _ _ _ (VThere (sig sz) _ _ _ (
-    VThere (sig sz) _ _ _ (VHere (sig sz) _ _))).
+  Definition var_store2 b1 b2 : var (sig Hdr_sz) (outer_ctx b1 b2) Store :=
+    VThere (sig Hdr_sz) _ _ _ (VThere (sig Hdr_sz) _ _ _ (
+    VThere (sig Hdr_sz) _ _ _ (VHere (sig Hdr_sz) _ _))).
 
   Definition outer_valu {b1 b2} buf1 buf2 store1 store2 :=
     VSnoc _ (fm_model a) (Bits b1) _ buf1 (
@@ -101,27 +101,27 @@ Section CompileConfRelSimplified.
             {c: bctx}
             (b1 b2: nat)
             (e: bit_expr Hdr c)
-    : tm (sig sz) (app_ctx (outer_ctx b1 b2) (compile_bctx c)) (be_sort b1 b2 e) :=
+    : tm (sig Hdr_sz) (app_ctx (outer_ctx b1 b2) (compile_bctx c)) (be_sort b1 b2 e) :=
     { compile_bit_expr b1 b2 (BELit _ _ l) :=
-        TFun (sig sz) (BitsLit _ (List.length l) (Ntuple.l2t l)) hnil;
+        TFun (sig Hdr_sz) (BitsLit _ (List.length l) (Ntuple.l2t l)) hnil;
       compile_bit_expr b1 b2 (BEBuf _ _ Left) :=
         TVar (weaken_var _ (var_buf1 b1 b2));
       compile_bit_expr b1 b2 (BEBuf _ _ Right) :=
         TVar (weaken_var _ (var_buf2 b1 b2));
       compile_bit_expr b1 b2 (BEHdr _ Left (P4A.HRVar h)) :=
-        TFun (sig sz) (Lookup _ h)
+        TFun (sig Hdr_sz) (Lookup _ h)
              (TVar (weaken_var _ (var_store1 b1 b2)) ::: hnil);
       compile_bit_expr b1 b2 (BEHdr _ Right (P4A.HRVar h)) :=
-        TFun (sig sz) (Lookup _ h)
+        TFun (sig Hdr_sz) (Lookup _ h)
              (TVar (weaken_var _ (var_store2 b1 b2)) ::: hnil);
       compile_bit_expr b1 b2 (BEVar _ b) :=
         TVar (reindex_var (compile_var b));
       compile_bit_expr b1 b2 (BESlice e hi lo) :=
-        TFun (sig sz) (Slice _ _ hi lo)
+        TFun (sig Hdr_sz) (Slice _ _ hi lo)
              (compile_bit_expr b1 b2 e ::: hnil);
       compile_bit_expr b1 b2 (BEConcat e1 e2) :=
       simplify_concat_zero (
-        TFun (sig sz) (Concat _ _ _)
+        TFun (sig Hdr_sz) (Concat _ _ _)
              (compile_bit_expr b1 b2 e1 :::
               compile_bit_expr b1 b2 e2 ::: hnil)) }.
 
@@ -129,13 +129,13 @@ Section CompileConfRelSimplified.
             {c: bctx}
             (b1 b2: nat)
             (r: store_rel Hdr c)
-            : fm (sig sz) (app_ctx (outer_ctx b1 b2) (compile_bctx c)) :=
+            : fm (sig Hdr_sz) (app_ctx (outer_ctx b1 b2) (compile_bctx c)) :=
     { compile_store_rel b1 b2 BRTrue := FTrue;
       compile_store_rel b1 b2 BRFalse := FFalse;
       compile_store_rel b1 b2 (BREq e1 e2) :=
-        match eq_dec (be_size sz b1 b2 e1) (be_size sz b1 b2 e2) with
+        match eq_dec (be_size Hdr_sz b1 b2 e1) (be_size Hdr_sz b1 b2 e2) with
         | left Heq =>
-          FEq (eq_rect _ (fun n => tm (sig sz) _ (Bits n))
+          FEq (eq_rect _ (fun n => tm (sig Hdr_sz) _ (Bits n))
                        (simplify_concat_zero (compile_bit_expr b1 b2 e1)) _ Heq)
               (simplify_concat_zero (compile_bit_expr b1 b2 e2))
         | right _ => FFalse
@@ -154,9 +154,9 @@ Section CompileConfRelSimplified.
   Definition compile_simplified_conf_rel
     (b1 b2: nat)
     (r: simplified_conf_rel Hdr)
-    : fm (sig sz) (outer_ctx b1 b2)
+    : fm (sig Hdr_sz) (outer_ctx b1 b2)
   :=
-    let sr: fm (sig sz) _ :=
+    let sr: fm (sig Hdr_sz) _ :=
         compile_store_rel b1 b2 (projT2 r)
     in
     quantify _ sr.
@@ -164,14 +164,14 @@ Section CompileConfRelSimplified.
   Definition compile_simplified_crel
     (b1 b2: nat)
     (R: simplified_crel Hdr)
-    : fm (sig sz) (outer_ctx b1 b2) :=
+    : fm (sig Hdr_sz) (outer_ctx b1 b2) :=
     List.fold_right (fun r f =>
       FAnd _ (compile_simplified_conf_rel b1 b2 r) f
     ) FTrue R.
 
   Definition compile_simplified_entailment
     (se: simplified_entailment a)
-    : fm (sig sz) (CEmp _) :=
+    : fm (sig Hdr_sz) (CEmp _) :=
     quantify_all _
       (FImpl (compile_simplified_crel
                se.(se_st).(cs_st1).(st_buf_len)
@@ -184,7 +184,7 @@ Section CompileConfRelSimplified.
 
   Definition compile_simplified_entailment'
     (se: simplified_entailment a)
-    : fm (sig sz) (CEmp _) :=
+    : fm (sig Hdr_sz) (CEmp _) :=
 
     quantify_all _
       (FImpl (compile_simplified_conf_rel
@@ -199,7 +199,7 @@ Section CompileConfRelSimplified.
   Lemma compile_bvar_correct:
     forall c bval (b: bvar c),
       interp_bvar bval b =
-      find (sig sz) (fm_model a) (compile_var b) (compile_bval bval).
+      find (sig Hdr_sz) (fm_model a) (compile_var b) (compile_bval bval).
   Proof.
     induction c; intros.
     - dependent destruction b.

--- a/lib/ConfRel.v
+++ b/lib/ConfRel.v
@@ -90,9 +90,9 @@ Section ConfRel.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
 
   Notation conf := (configuration (P4A.interp a)).
 
@@ -229,7 +229,7 @@ Section ConfRel.
       | Left => b1
       | Right => b2
       end
-    | BEHdr a (P4A.HRVar h) => sz h
+    | BEHdr a (P4A.HRVar h) => Hdr_sz h
     | BEVar x => check_bvar x
     | BESlice e hi lo =>
       Nat.min (1 + hi) (be_size b1 b2 e) - lo

--- a/lib/FirstOrderBitVec.v
+++ b/lib/FirstOrderBitVec.v
@@ -19,9 +19,9 @@ Section FirstOrderBitVec.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
 
   Inductive sorts: Type :=
   | Bits (n: nat).

--- a/lib/FirstOrderConfRel.v
+++ b/lib/FirstOrderConfRel.v
@@ -19,9 +19,9 @@ Section AutModel.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
 
   Notation conf := (configuration (P4A.interp a)).
 
@@ -42,8 +42,8 @@ Section AutModel.
   | NatLit: forall n : nat, funs [] Natural
   | Concat: forall n m, funs [Bits n; Bits m] (Bits (n + m))
   | Slice: forall n hi lo, funs [Bits n] (Bits (Nat.min (1 + hi) n - lo))
-  | Lookup: forall k, funs [Store] (Bits (sz k))
-  | Update: forall k, funs [Store; Bits (sz k)] Store
+  | Lookup: forall k, funs [Store] (Bits (Hdr_sz k))
+  | Update: forall k, funs [Store; Bits (Hdr_sz k)] Store
   | State1: forall n m, funs [ConfigPair n m] State
   | Store1: forall n m, funs [ConfigPair n m] Store
   | State2: forall n m, funs [ConfigPair n m] State
@@ -84,11 +84,11 @@ Section AutModel.
       mod_fns (Slice n hi lo) (xs ::: hnil) :=
         n_tuple_slice hi lo xs;
       mod_fns (Lookup k) (store ::: hnil) :=
-        match P4A.find Hdr sz k store with
+        match P4A.find Hdr Hdr_sz k store with
         | P4A.VBits _ v => v
         end;
       mod_fns (Update k) (store ::: v ::: hnil) :=
-        P4A.assign Hdr sz k (P4A.VBits _ v) store;
+        P4A.assign Hdr Hdr_sz k (P4A.VBits _ v) store;
       mod_fns (State1 _ _) ((q1, q2) ::: hnil) := (proj1_sig q1).(conf_state);
       mod_fns (Store1 _ _) ((q1, q2) ::: hnil) := (proj1_sig q1).(conf_store);
       mod_fns (State2 _ _) ((q1, q2) ::: hnil) := (proj1_sig q2).(conf_state);

--- a/lib/FirstOrderConfRelSimplified.v
+++ b/lib/FirstOrderConfRelSimplified.v
@@ -21,9 +21,9 @@ Section AutModel.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
 
   Inductive sorts: Type :=
   | Bits (n: nat)
@@ -34,7 +34,7 @@ Section AutModel.
   | BitsLit: forall n, n_tuple bool n -> funs [] (Bits n)
   | Concat: forall n m, funs [Bits n; Bits m] (Bits (n + m))
   | Slice: forall n hi lo, funs [Bits n] (Bits (Nat.min (1 + hi) n - lo))
-  | Lookup: forall h, funs [Store] (Bits (sz h)).
+  | Lookup: forall h, funs [Store] (Bits (Hdr_sz h)).
 
   Inductive rels: arity sorts -> Type :=.
 
@@ -64,7 +64,7 @@ Section AutModel.
       mod_fns (Slice n hi lo) (xs ::: hnil) :=
         n_tuple_slice hi lo xs;
       mod_fns (Lookup k) (store ::: hnil) :=
-        match P4A.find Hdr sz k store with
+        match P4A.find Hdr Hdr_sz k store with
         | P4A.VBits _ v => v
         end
     }.

--- a/lib/Reachability.v
+++ b/lib/Reachability.v
@@ -26,9 +26,9 @@ Section ReachablePairs.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
 
   Notation conf := (configuration (P4A.interp a)).
 

--- a/lib/Sum.v
+++ b/lib/Sum.v
@@ -23,17 +23,17 @@ Section Sum.
 
   (* Header identifiers. *)
   Variable (Hdr1: Type).
-  Variable (sz1 : Hdr1 -> nat).
+  Variable (Hdr1_sz : Hdr1 -> nat).
   Context `{Hdr1_eq_dec: EquivDec.EqDec Hdr1 eq}.
   Context `{Hdr1_finite: @Finite Hdr1 _ Hdr1_eq_dec}.
 
   Variable (Hdr2: Type).
-  Variable (sz2 : Hdr2 -> nat).
+  Variable (Hdr2_sz : Hdr2 -> nat).
   Context `{Hdr2_eq_dec: EquivDec.EqDec Hdr2 eq}.
   Context `{Hdr2_finite: @Finite Hdr2 _ Hdr2_eq_dec}.
 
-  Variable (a1: Syntax.t St1 sz1).
-  Variable (a2: Syntax.t St2 sz2).
+  Variable (a1: Syntax.t St1 Hdr1_sz).
+  Variable (a2: Syntax.t St2 Hdr2_sz).
 
   Notation St := (St1 + St2)%type.
 
@@ -43,7 +43,7 @@ Section Sum.
   Global Instance St_finite: @Finite St _ St_eq_dec :=
     ltac:(typeclasses eauto).
 
-  Definition H : Type := Hdr1 + Hdr2.
+  Definition Hdr : Type := Hdr1 + Hdr2.
 
   Definition make_transparent {X: Type} (eq_dec: forall (x0 x1: X), {x0 = x1} + {x0 <> x1}) {l r} (opaque_eq: l = r) : l = r :=
     match eq_dec l r with
@@ -51,17 +51,17 @@ Section Sum.
     | _ => opaque_eq
     end.
 
-  Definition sz (h: H) : nat :=
+  Definition Hdr_sz (h: Hdr) : nat :=
     match h with
-    | inl h => sz1 h
-    | inr h => sz2 h
+    | inl h => Hdr1_sz h
+    | inr h => Hdr2_sz h
     end.
 
-  Program Definition sum : Syntax.t St sz :=
+  Program Definition sum : Syntax.t St Hdr_sz :=
     {| Syntax.t_states s :=
          match s with
-         | inl s1 => Syntax.state_fmapSH sz inl inl _ (a1.(Syntax.t_states) s1)
-         | inr s2 => Syntax.state_fmapSH sz inr inr _ (a2.(Syntax.t_states) s2)
+         | inl s1 => Syntax.state_fmapSH Hdr_sz inl inl _ (a1.(Syntax.t_states) s1)
+         | inr s2 => Syntax.state_fmapSH Hdr_sz inr inr _ (a2.(Syntax.t_states) s2)
          end |}.
   Next Obligation.
     destruct h; simpl.

--- a/lib/WPProofs.v
+++ b/lib/WPProofs.v
@@ -26,9 +26,9 @@ Section WPProofs.
   Variable (Hdr: Type).
   Context `{Hdr_eq_dec: EquivDec.EqDec Hdr eq}.
   Context `{Hdr_finite: @Finite Hdr _ Hdr_eq_dec}.
-  Variable (sz: Hdr -> nat).
+  Variable (Hdr_sz: Hdr -> nat).
 
-  Variable (a: P4A.t St sz).
+  Variable (a: P4A.t St Hdr_sz).
   Notation conf := (configuration (P4A.interp a)).
 
   Definition pick {A} (s: side) (x: A * A) :=
@@ -96,8 +96,8 @@ Section WPProofs.
 
   Lemma beslice_interp_length:
     forall b1 b2 ctx e hi lo,
-      @be_size Hdr sz ctx b1 b2 (beslice e hi lo) =
-      @be_size Hdr sz ctx b1 b2 (BESlice e hi lo).
+      @be_size Hdr Hdr_sz ctx b1 b2 (beslice e hi lo) =
+      @be_size Hdr Hdr_sz ctx b1 b2 (BESlice e hi lo).
   Proof.
     intros.
     unfold beslice.
@@ -106,7 +106,7 @@ Section WPProofs.
       rewrite P4A.slice_len.
       Lia.lia.
     - unfold be_size.
-      fold (be_size sz b1 b2 e).
+      fold (be_size Hdr_sz b1 b2 e).
       Lia.lia.
   Qed.
 
@@ -142,14 +142,14 @@ Section WPProofs.
     - apply slice_n_tuple_slice_eq.
     - generalize (interp_bit_expr e valu buf1 buf2 store1 store2) as t; intros.
       apply t2l_eq.
-      unfold be_size; fold (be_size sz b1 b2 e).
+      unfold be_size; fold (be_size Hdr_sz b1 b2 e).
       repeat rewrite t2l_n_tuple_slice.
       now rewrite slice_slice.
   Qed.
 
   Lemma beconcat_interp_length:
     forall ctx (e1 e2: bit_expr Hdr ctx) l1 l2,
-      be_size sz l1 l2 (beconcat e1 e2) = be_size sz l1 l2 (BEConcat e1 e2).
+      be_size Hdr_sz l1 l2 (beconcat e1 e2) = be_size Hdr_sz l1 l2 (BEConcat e1 e2).
   Proof.
     induction e1; destruct e2; intros; simpl; auto.
     apply app_length.
@@ -169,8 +169,8 @@ Section WPProofs.
 
   Lemma be_subst_be_size:
     forall c l1 l2 h phi (exp: bit_expr Hdr c),
-      be_size sz l1 l2 h = be_size sz l1 l2 exp ->
-      be_size sz l1 l2 phi = be_size sz l1 l2 (be_subst phi exp h).
+      be_size Hdr_sz l1 l2 h = be_size Hdr_sz l1 l2 exp ->
+      be_size Hdr_sz l1 l2 phi = be_size Hdr_sz l1 l2 (be_subst phi exp h).
   Proof.
     induction phi; intros; simpl;
       repeat match goal with
@@ -203,12 +203,12 @@ Section WPProofs.
       st2
       bs2
       (buf2: Ntuple.n_tuple bool bs2)
-      (w: Ntuple.n_tuple bool (sz hdr)),
+      (w: Ntuple.n_tuple bool (Hdr_sz hdr)),
       interp_bit_expr exp valu buf1 buf2 st1 st2 ~= w ->
       interp_bit_expr (a:=a) phi valu
                       buf1
                       buf2
-                      (P4A.assign _ sz hdr (P4A.VBits (sz hdr) w) st1)
+                      (P4A.assign _ Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st1)
                       st2
       ~=
       interp_bit_expr (WP.be_subst phi exp (BEHdr c Left (P4A.HRVar hdr)))
@@ -275,13 +275,13 @@ Section WPProofs.
       st2
       bs2
       (buf2: Ntuple.n_tuple bool bs2)
-      (w: Ntuple.n_tuple bool (sz hdr)),
+      (w: Ntuple.n_tuple bool (Hdr_sz hdr)),
       interp_bit_expr exp valu buf1 buf2 st1 st2 ~= w ->
       interp_bit_expr (a:=a) phi valu
                       buf1
                       buf2
                       st1
-                      (P4A.assign _ sz hdr (P4A.VBits (sz hdr) w) st2)
+                      (P4A.assign _ Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st2)
       ~=
       interp_bit_expr (WP.be_subst phi exp (BEHdr c Right (P4A.HRVar hdr)))
                       valu
@@ -347,7 +347,7 @@ Section WPProofs.
       st2
       bs2
       (buf2: n_tuple bool bs2)
-      (w: Ntuple.n_tuple bool (sz hdr)),
+      (w: Ntuple.n_tuple bool (Hdr_sz hdr)),
       w ~= interp_bit_expr exp valu buf1 buf2 st1 st2 ->
       interp_store_rel
         (a:=a)
@@ -364,7 +364,7 @@ Section WPProofs.
         valu
         buf1
         buf2
-        (P4A.assign _ sz hdr (P4A.VBits (sz hdr) w) st1)
+        (P4A.assign _ Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st1)
         st2.
   Proof.
     induction phi;
@@ -386,83 +386,83 @@ Section WPProofs.
     - tauto.
     - tauto.
     - revert H0.
-      assert (be_size sz bs1 bs2 exp = sz hdr).
+      assert (be_size Hdr_sz bs1 bs2 exp = Hdr_sz hdr).
       {
         eapply n_tuple_inj.
         now inversion H.
       }
-      assert (Hsize1: be_size sz bs1 bs2 (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr)))
-              = be_size sz bs1 bs2 e1).
+      assert (Hsize1: be_size Hdr_sz bs1 bs2 (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr)))
+              = be_size Hdr_sz bs1 bs2 e1).
       {
         rewrite <- !be_subst_be_size; auto.
       }
-      assert (Hsize2: be_size sz bs1 bs2 (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr)))
-              = be_size sz bs1 bs2 e2).
+      assert (Hsize2: be_size Hdr_sz bs1 bs2 (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr)))
+              = be_size Hdr_sz bs1 bs2 e2).
       {
         rewrite <- !be_subst_be_size; auto.
       }
       revert Hsize2 Hsize1.
-      assert (Heq1: interp_bit_expr (a:=a) e1 valu buf1 buf2 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st1) st2 ~=
+      assert (Heq1: interp_bit_expr (a:=a) e1 valu buf1 buf2 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st1) st2 ~=
                                     interp_bit_expr (a:=a) (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr))) valu buf1 buf2 st1 st2)
         by now apply be_subst_hdr_left.
-      assert (Heq2: interp_bit_expr (a:=a) e2 valu buf1 buf2 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st1) st2
+      assert (Heq2: interp_bit_expr (a:=a) e2 valu buf1 buf2 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st1) st2
                               ~=
                               interp_bit_expr (a:=a) (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr))) valu buf1 buf2 st1 st2)
         by now apply be_subst_hdr_left.
       revert Heq1 Heq2.
       generalize (interp_bit_expr (a:=a) (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr))) valu buf1 buf2 st1 st2).
-      generalize (be_size sz bs1 bs2 (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr)))).
+      generalize (be_size Hdr_sz bs1 bs2 (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr)))).
       generalize (interp_bit_expr (a:=a) (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr))) valu buf1 buf2 st1 st2).
-      generalize (be_size sz bs1 bs2 (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr)))).
+      generalize (be_size Hdr_sz bs1 bs2 (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr)))).
       intros.
       revert Heq1 Heq2.
       revert H1.
-      generalize (interp_bit_expr (a:=a) e1 valu buf1 buf2 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st1) st2).
-      generalize (interp_bit_expr (a:=a) e2 valu buf1 buf2 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st1) st2).
+      generalize (interp_bit_expr (a:=a) e1 valu buf1 buf2 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st1) st2).
+      generalize (interp_bit_expr (a:=a) e2 valu buf1 buf2 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st1) st2).
       revert Hsize2 Hsize1.
-      generalize (be_size sz bs1 bs2 e1).
-      generalize (be_size sz bs1 bs2 e2).
+      generalize (be_size Hdr_sz bs1 bs2 e1).
+      generalize (be_size Hdr_sz bs1 bs2 e2).
       intros.
       subst.
       now destruct (Classes.eq_dec n4 n3).
     - revert H0.
-      assert (be_size sz bs1 bs2 exp = sz hdr).
+      assert (be_size Hdr_sz bs1 bs2 exp = Hdr_sz hdr).
       {
         eapply n_tuple_inj.
         now inversion H.
       }
-      assert (Hsize1: be_size sz bs1 bs2 (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr))) = be_size sz bs1 bs2 e1).
+      assert (Hsize1: be_size Hdr_sz bs1 bs2 (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr))) = be_size Hdr_sz bs1 bs2 e1).
       {
         rewrite <- !be_subst_be_size; auto.
       }
-      assert (Hsize2: be_size sz bs1 bs2 (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr))) = be_size sz bs1 bs2 e2).
+      assert (Hsize2: be_size Hdr_sz bs1 bs2 (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr))) = be_size Hdr_sz bs1 bs2 e2).
       {
         rewrite <- !be_subst_be_size; auto.
       }
       revert Hsize2 Hsize1.
-      assert (Heq1: interp_bit_expr e1 valu buf1 buf2 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st1) st2
+      assert (Heq1: interp_bit_expr e1 valu buf1 buf2 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st1) st2
                               ~=
                               interp_bit_expr (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr))) valu buf1 buf2
                               st1 st2)
         by now apply be_subst_hdr_left.
-      assert (Heq2: interp_bit_expr e2 valu buf1 buf2 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st1) st2
+      assert (Heq2: interp_bit_expr e2 valu buf1 buf2 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st1) st2
                               ~=
                               interp_bit_expr (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr))) valu buf1 buf2
                               st1 st2)
         by now apply be_subst_hdr_left.
       revert Heq1 Heq2.
       generalize (interp_bit_expr (a:=a) (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr))) valu buf1 buf2 st1 st2).
-      generalize (be_size sz bs1 bs2 (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr)))).
+      generalize (be_size Hdr_sz bs1 bs2 (be_subst e1 exp (BEHdr c Left (P4A.HRVar hdr)))).
       generalize (interp_bit_expr (a:=a) (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr))) valu buf1 buf2 st1 st2).
-      generalize (be_size sz bs1 bs2 (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr)))).
+      generalize (be_size Hdr_sz bs1 bs2 (be_subst e2 exp (BEHdr c Left (P4A.HRVar hdr)))).
       intros.
       revert Heq1 Heq2.
       revert H1.
-      generalize (interp_bit_expr (a:=a) e1 valu buf1 buf2 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st1) st2).
-      generalize (interp_bit_expr (a:=a) e2 valu buf1 buf2 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st1) st2).
+      generalize (interp_bit_expr (a:=a) e1 valu buf1 buf2 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st1) st2).
+      generalize (interp_bit_expr (a:=a) e2 valu buf1 buf2 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st1) st2).
       revert Hsize2 Hsize1.
-      generalize (be_size sz bs1 bs2 e1).
-      generalize (be_size sz bs1 bs2 e2).
+      generalize (be_size Hdr_sz bs1 bs2 e1).
+      generalize (be_size Hdr_sz bs1 bs2 e2).
       intros.
       subst.
       now destruct (Classes.eq_dec n4 n3).
@@ -490,7 +490,7 @@ Section WPProofs.
       st2
       bs2
       (buf2: n_tuple bool bs2)
-      (w: Ntuple.n_tuple bool (sz hdr)),
+      (w: Ntuple.n_tuple bool (Hdr_sz hdr)),
       w ~= interp_bit_expr exp valu buf1 buf2 st1 st2 ->
       interp_store_rel
         (a:=a)
@@ -508,7 +508,7 @@ Section WPProofs.
         buf1
         buf2
         st1
-        (P4A.assign _ sz hdr (P4A.VBits (sz hdr) w) st2).
+        (P4A.assign _ Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st2).
   Proof.
     induction phi;
       simpl in *;
@@ -529,81 +529,81 @@ Section WPProofs.
     - tauto.
     - tauto.
     - revert H0.
-      assert (be_size sz bs1 bs2 exp = sz hdr).
+      assert (be_size Hdr_sz bs1 bs2 exp = Hdr_sz hdr).
       {
         eapply n_tuple_inj.
         now inversion H.
       }
-      assert (Hsize1: be_size sz bs1 bs2 (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr))) = be_size sz bs1 bs2 e1).
+      assert (Hsize1: be_size Hdr_sz bs1 bs2 (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr))) = be_size Hdr_sz bs1 bs2 e1).
       {
         rewrite <- !be_subst_be_size; auto.
       }
-      assert (Hsize2: be_size sz bs1 bs2 (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr))) = be_size sz bs1 bs2 e2).
+      assert (Hsize2: be_size Hdr_sz bs1 bs2 (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr))) = be_size Hdr_sz bs1 bs2 e2).
       {
         rewrite <- !be_subst_be_size; auto.
       }
       revert Hsize2 Hsize1.
-      assert (Heq1: interp_bit_expr (a:=a) e1 valu buf1 buf2 st1 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st2) ~=
+      assert (Heq1: interp_bit_expr (a:=a) e1 valu buf1 buf2 st1 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st2) ~=
                                     interp_bit_expr (a:=a) (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr))) valu buf1 buf2 st1 st2)
         by now apply be_subst_hdr_right.
-      assert (Heq2: interp_bit_expr (a:=a) e2 valu buf1 buf2 st1 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st2)
+      assert (Heq2: interp_bit_expr (a:=a) e2 valu buf1 buf2 st1 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st2)
                               ~=
                               interp_bit_expr (a:=a) (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr))) valu buf1 buf2 st1 st2)
         by now apply be_subst_hdr_right.
       revert Heq1 Heq2.
       generalize (interp_bit_expr (a:=a) (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr))) valu buf1 buf2 st1 st2).
-      generalize (be_size sz bs1 bs2 (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr)))).
+      generalize (be_size Hdr_sz bs1 bs2 (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr)))).
       generalize (interp_bit_expr (a:=a) (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr))) valu buf1 buf2 st1 st2).
-      generalize (be_size sz bs1 bs2 (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr)))).
+      generalize (be_size Hdr_sz bs1 bs2 (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr)))).
       intros.
       revert Heq1 Heq2.
       revert H1.
-      generalize (interp_bit_expr (a:=a) e1 valu buf1 buf2 st1 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st2)).
-      generalize (interp_bit_expr (a:=a) e2 valu buf1 buf2 st1 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st2)).
+      generalize (interp_bit_expr (a:=a) e1 valu buf1 buf2 st1 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st2)).
+      generalize (interp_bit_expr (a:=a) e2 valu buf1 buf2 st1 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st2)).
       revert Hsize2 Hsize1.
-      generalize (be_size sz bs1 bs2 e1).
-      generalize (be_size sz bs1 bs2 e2).
+      generalize (be_size Hdr_sz bs1 bs2 e1).
+      generalize (be_size Hdr_sz bs1 bs2 e2).
       intros.
       subst.
       now destruct (Classes.eq_dec n4 n3).
     - revert H0.
-      assert (be_size sz bs1 bs2 exp = sz hdr).
+      assert (be_size Hdr_sz bs1 bs2 exp = Hdr_sz hdr).
       {
         eapply n_tuple_inj.
         now inversion H.
       }
-      assert (Hsize1: be_size sz bs1 bs2 (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr))) = be_size sz bs1 bs2 e1).
+      assert (Hsize1: be_size Hdr_sz bs1 bs2 (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr))) = be_size Hdr_sz bs1 bs2 e1).
       {
         rewrite <- !be_subst_be_size; auto.
       }
-      assert (Hsize2: be_size sz bs1 bs2 (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr))) = be_size sz bs1 bs2 e2).
+      assert (Hsize2: be_size Hdr_sz bs1 bs2 (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr))) = be_size Hdr_sz bs1 bs2 e2).
       {
         rewrite <- !be_subst_be_size; auto.
       }
       revert Hsize2 Hsize1.
-      assert (Heq1: interp_bit_expr e1 valu buf1 buf2 st1 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st2)
+      assert (Heq1: interp_bit_expr e1 valu buf1 buf2 st1 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st2)
                               ~=
                               interp_bit_expr (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr))) valu buf1 buf2
                               st1 st2)
         by now apply be_subst_hdr_right.
-      assert (Heq2: interp_bit_expr e2 valu buf1 buf2 st1 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st2)
+      assert (Heq2: interp_bit_expr e2 valu buf1 buf2 st1 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st2)
                               ~=
                               interp_bit_expr (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr))) valu buf1 buf2
                               st1 st2)
         by now apply be_subst_hdr_right.
       revert Heq1 Heq2.
       generalize (interp_bit_expr (a:=a) (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr))) valu buf1 buf2 st1 st2).
-      generalize (be_size sz bs1 bs2 (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr)))).
+      generalize (be_size Hdr_sz bs1 bs2 (be_subst e1 exp (BEHdr c Right (P4A.HRVar hdr)))).
       generalize (interp_bit_expr (a:=a) (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr))) valu buf1 buf2 st1 st2).
-      generalize (be_size sz bs1 bs2 (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr)))).
+      generalize (be_size Hdr_sz bs1 bs2 (be_subst e2 exp (BEHdr c Right (P4A.HRVar hdr)))).
       intros.
       revert Heq1 Heq2.
       revert H1.
-      generalize (interp_bit_expr (a:=a) e1 valu buf1 buf2 st1 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st2)).
-      generalize (interp_bit_expr (a:=a) e2 valu buf1 buf2 st1 (P4A.assign Hdr sz hdr (P4A.VBits (sz hdr) w) st2)).
+      generalize (interp_bit_expr (a:=a) e1 valu buf1 buf2 st1 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st2)).
+      generalize (interp_bit_expr (a:=a) e2 valu buf1 buf2 st1 (P4A.assign Hdr Hdr_sz hdr (P4A.VBits (Hdr_sz hdr) w) st2)).
       revert Hsize2 Hsize1.
-      generalize (be_size sz bs1 bs2 e1).
-      generalize (be_size sz bs1 bs2 e2).
+      generalize (be_size Hdr_sz bs1 bs2 e1).
+      generalize (be_size Hdr_sz bs1 bs2 e2).
       intros.
       subst.
       now destruct (Classes.eq_dec n4 n3).
@@ -704,25 +704,25 @@ Section WPProofs.
     - pose proof (He1 := be_subst_buf si c e1 exp store1 store2 len1 len2 buf1 buf2 valu _ _ w1 w2 ltac:(eauto)).
       pose proof (He2 := be_subst_buf si c e2 exp store1 store2 len1 len2 buf1 buf2 valu _ _ w1 w2 ltac:(eauto)).
       assert (Hsize1: pick si
-                   (n_tuple bool (be_size sz b1 len2 e1),
-                    n_tuple bool (be_size sz len1 b2 e1)) =
+                   (n_tuple bool (be_size Hdr_sz b1 len2 e1),
+                    n_tuple bool (be_size Hdr_sz len1 b2 e1)) =
               n_tuple bool
-                      (be_size sz len1 len2
+                      (be_size Hdr_sz len1 len2
                                (be_subst e1 exp (BEBuf Hdr c si))))
         by (inversion He1; auto).
       assert (Hsize2: pick si
-                   (n_tuple bool (be_size sz b1 len2 e2),
-                    n_tuple bool (be_size sz len1 b2 e2)) =
+                   (n_tuple bool (be_size Hdr_sz b1 len2 e2),
+                    n_tuple bool (be_size Hdr_sz len1 b2 e2)) =
               n_tuple bool
-                      (be_size sz len1 len2
+                      (be_size Hdr_sz len1 len2
                                (be_subst e2 exp (BEBuf Hdr c si))))
         by (inversion He2; auto).
       revert He1 He2 Hsize1 Hsize2.
       repeat match goal with
              | |- context[interp_bit_expr ?e ?v ?b1 ?b2 ?st1 ?st2] =>
                generalize (interp_bit_expr (a:=a) e v b1 b2 st1 st2)
-             | |- context[be_size sz ?b1 ?b2 ?e] =>
-               generalize (be_size sz b1 b2 e)
+             | |- context[be_size Hdr_sz ?b1 ?b2 ?e] =>
+               generalize (be_size Hdr_sz b1 b2 e)
              end.
       intros.
       destruct si; simpl in *;
@@ -747,7 +747,7 @@ Section WPProofs.
   Qed.
 
   Lemma wp_op'_size:
-    forall (c: bctx) si (o: P4A.op sz) n phi m phi',
+    forall (c: bctx) si (o: P4A.op Hdr_sz) n phi m phi',
       WP.wp_op' (c:=c) si o (P4A.op_size o + n, phi) = (m, phi') ->
       m = n.
   Proof.
@@ -762,13 +762,13 @@ Section WPProofs.
       subst n0.
       apply IHo1 in H.
       eauto.
-    - replace (sz hdr + n - sz hdr) with n in * by Lia.lia.
+    - replace (Hdr_sz hdr + n - Hdr_sz hdr) with n in * by Lia.lia.
       congruence.
     - congruence.
   Qed.
 
   Lemma wp_op'_seq:
-    forall (c: bctx) (o1: P4A.op sz) (o2: P4A.op sz) si phi,
+    forall (c: bctx) (o1: P4A.op Hdr_sz) (o2: P4A.op Hdr_sz) si phi,
       WP.wp_op' (c:=c) si (P4A.OpSeq o1 o2) phi = WP.wp_op' si o1 (WP.wp_op' si o2 phi).
   Proof.
     induction o1; intros; simpl;
@@ -781,7 +781,7 @@ Section WPProofs.
   Qed.
 
   Lemma wp_op'_mono:
-    forall (c: bctx) si (o: P4A.op sz) n phi,
+    forall (c: bctx) si (o: P4A.op Hdr_sz) n phi,
       fst (WP.wp_op' (c:=c) si o (n, phi)) <= n.
   Proof.
     induction o; simpl.
@@ -914,14 +914,14 @@ Section WPProofs.
   Qed.
 
   Lemma expr_to_bit_expr_sound:
-    forall (c: bctx) si (valu: bval c) n (expr: P4A.expr sz n)
+    forall (c: bctx) si (valu: bval c) n (expr: P4A.expr Hdr_sz n)
       bs1
       (buf1: n_tuple bool bs1)
       st1
       bs2
       (buf2: n_tuple bool bs2)
       st2,
-      P4A.eval_expr Hdr sz n (pick si (st1, st2)) expr ~=
+      P4A.eval_expr Hdr Hdr_sz n (pick si (st1, st2)) expr ~=
       P4A.VBits _ (interp_bit_expr (a:=a) (WP.expr_to_bit_expr si expr) valu buf1 buf2 st1 st2).
   Proof.
     assert (Hv: forall n v, P4A.VBits n (match v with P4A.VBits _ v' => v' end) = v).
@@ -948,19 +948,19 @@ Section WPProofs.
       reflexivity.
     - simpl (expr_to_bit_expr _ _).
       autorewrite with eval_expr interp_bit_expr in *.
-      assert (P4A.eval_expr Hdr sz n (pick si (st1, st2)) expr ~=
+      assert (P4A.eval_expr Hdr Hdr_sz n (pick si (st1, st2)) expr ~=
            P4A.VBits
-             (be_size sz bs1 bs2 (expr_to_bit_expr si expr))
+             (be_size Hdr_sz bs1 bs2 (expr_to_bit_expr si expr))
              (interp_bit_expr (expr_to_bit_expr si expr) valu buf1 buf2 st1 st2))
         by auto.
-      destruct (P4A.eval_expr Hdr sz n (pick si (st1, st2)) expr) eqn:?.
+      destruct (P4A.eval_expr Hdr Hdr_sz n (pick si (st1, st2)) expr) eqn:?.
       rename n0 into val_e.
       generalize dependent val_e.
       generalize (interp_bit_expr (a:=a) (expr_to_bit_expr si expr) valu
                                   buf1 buf2 st1 st2)
         as val.
       simpl be_size.
-      generalize (@be_size Hdr sz c bs1 bs2 (expr_to_bit_expr si expr)) as m.
+      generalize (@be_size Hdr Hdr_sz c bs1 bs2 (expr_to_bit_expr si expr)) as m.
       intros m.
       change (match m with
               | 0 => 0
@@ -977,8 +977,8 @@ Section WPProofs.
       reflexivity.
     - autorewrite with eval_expr in *.
       autorewrite with interp_bit_expr in *.
-      destruct (P4A.eval_expr Hdr sz n (pick si (st1, st2)) expr1) eqn:?.
-      destruct (P4A.eval_expr Hdr sz m (pick si (st1, st2)) expr2) eqn:?.
+      destruct (P4A.eval_expr Hdr Hdr_sz n (pick si (st1, st2)) expr1) eqn:?.
+      destruct (P4A.eval_expr Hdr Hdr_sz m (pick si (st1, st2)) expr2) eqn:?.
       simpl.
       eapply vbits_congr.
       autorewrite with interp_bit_expr.
@@ -1023,16 +1023,16 @@ Section WPProofs.
   Qed.
 
   Lemma eval_op_congr':
-    forall (st: P4A.store Hdr sz)
-      (op: P4A.op sz)
+    forall (st: P4A.store Hdr Hdr_sz)
+      (op: P4A.op Hdr_sz)
       (buf: n_tuple bool (P4A.op_size op))
       st'
-      (op': P4A.op sz)
+      (op': P4A.op Hdr_sz)
       (buf': n_tuple bool (P4A.op_size op')),
       st = st' ->
       buf ~= buf' ->
       op ~= op' ->
-      P4A.eval_op Hdr sz st op buf = P4A.eval_op Hdr sz st' op' buf'.
+      P4A.eval_op Hdr Hdr_sz st op buf = P4A.eval_op Hdr Hdr_sz st' op' buf'.
   Proof.
     intros.
     subst.
@@ -1040,16 +1040,16 @@ Section WPProofs.
   Qed.
 
   Lemma eval_op_congr:
-    forall (st: P4A.store Hdr sz)
-      (op: P4A.op sz)
+    forall (st: P4A.store Hdr Hdr_sz)
+      (op: P4A.op Hdr_sz)
       (buf: n_tuple bool (P4A.op_size op))
       st'
-      (op': P4A.op sz)
+      (op': P4A.op Hdr_sz)
       (buf': n_tuple bool (P4A.op_size op')),
       st = st' ->
       buf ~= buf' ->
       op ~= op' ->
-      P4A.eval_op Hdr sz st op buf ~= P4A.eval_op Hdr sz st' op' buf'.
+      P4A.eval_op Hdr Hdr_sz st op buf ~= P4A.eval_op Hdr Hdr_sz st' op' buf'.
   Proof.
     intros.
     erewrite eval_op_congr' by eauto.
@@ -1057,7 +1057,7 @@ Section WPProofs.
   Qed.
 
   Lemma wp_op'_spec_l:
-    forall c (valu: bval c) (o: P4A.op sz) n m phi st1
+    forall c (valu: bval c) (o: P4A.op Hdr_sz) n m phi st1
       (buf1: n_tuple bool (n + P4A.op_size o + m)) (buf1': n_tuple bool (P4A.op_size o)) len2 (buf2: n_tuple bool len2) st2,
       buf1' ~= n_tuple_take_n (P4A.op_size o) (n_tuple_skip_n n buf1) ->
       interp_store_rel (a:=a)
@@ -1106,9 +1106,9 @@ Section WPProofs.
       rewrite IHo1'.
       autorewrite with eval_op.
       unfold P4A.op_size.
-      set (st1' := @ConfRel.P4A.eval_op Hdr equiv1 Hdr_eq_dec Hdr_finite sz st1 o1
+      set (st1' := @ConfRel.P4A.eval_op Hdr equiv1 Hdr_eq_dec Hdr_finite Hdr_sz st1 o1
           (@rewrite_size bool (Nat.min (P4A.op_size o1) (P4A.op_size o1 + P4A.op_size o2)) (P4A.op_size o1)
-             (ConfRel.P4A.eval_op_obligations_obligation_1 Hdr sz o1 o2)
+             (ConfRel.P4A.eval_op_obligations_obligation_1 Hdr Hdr_sz o1 o2)
              (@n_tuple_take_n bool (P4A.op_size o1 + P4A.op_size o2) (P4A.op_size o1) buf1'))).
       assert (Hsz2: n + P4A.op_size o1 + P4A.op_size o2 + m = n + (P4A.op_size o1 + P4A.op_size o2) + m) by Lia.lia.
       pose (ibuf2 := rewrite_size Hsz2 buf1).
@@ -1121,7 +1121,7 @@ Section WPProofs.
         with (n + P4A.op_size o1 + P4A.op_size o2)
         in Heqp by Lia.lia.
       rewrite Heqp in IHo2'.
-      assert (Hst1': st1' = ConfRel.P4A.eval_op Hdr sz st1 o1 ibuf1').
+      assert (Hst1': st1' = ConfRel.P4A.eval_op Hdr Hdr_sz st1 o1 ibuf1').
       {
         unfold st1'.
         change (ConfRel.P4A.eval_op) with P4A.eval_op.
@@ -1183,26 +1183,26 @@ Section WPProofs.
       reflexivity.
       autorewrite with interp_bit_expr.
       unfold n_tuple_slice.
-      replace (n + sz hdr - sz hdr) with n by Lia.lia.
+      replace (n + Hdr_sz hdr - Hdr_sz hdr) with n by Lia.lia.
       rewrite H.
       apply JMeq_trans
-        with (y := n_tuple_skip_n n (n_tuple_take_n (n + sz hdr) buf1)).
+        with (y := n_tuple_skip_n n (n_tuple_take_n (n + Hdr_sz hdr) buf1)).
       + apply t2l_eq.
         rewrite ?t2l_n_tuple_take_n, ?t2l_n_tuple_skip_n.
         rewrite firstn_skipn_comm.
         rewrite ?t2l_n_tuple_take_n, ?t2l_n_tuple_skip_n.
         reflexivity.
       + eapply n_tuple_skip_n_congr; auto.
-        replace (1 + (n + sz hdr - 1)) with (n + sz hdr).
+        replace (1 + (n + Hdr_sz hdr - 1)) with (n + Hdr_sz hdr).
         reflexivity.
-        assert (sz hdr > 0) by (apply a).
+        assert (Hdr_sz hdr > 0) by (apply a).
         Lia.lia.
     - simpl.
       intros.
-      pose proof (expr_to_bit_expr_sound c Left valu (sz lhs) rhs _ buf1 st1 len2 buf2 st2).
+      pose proof (expr_to_bit_expr_sound c Left valu (Hdr_sz lhs) rhs _ buf1 st1 len2 buf2 st2).
       simpl in *.
-      destruct (P4A.eval_expr Hdr sz _ _ rhs) eqn:?.
-      assert (sz lhs = @be_size Hdr sz c (n + 0 + m) len2 (expr_to_bit_expr Left rhs)).
+      destruct (P4A.eval_expr Hdr Hdr_sz _ _ rhs) eqn:?.
+      assert (Hdr_sz lhs = @be_size Hdr Hdr_sz c (n + 0 + m) len2 (expr_to_bit_expr Left rhs)).
       {
         inversion H0.
         apply v_inj; eauto.
@@ -1218,7 +1218,7 @@ Section WPProofs.
   Qed.
 
   Lemma wp_op'_spec_r:
-    forall c (valu: bval c) (o: P4A.op sz) n m phi st2
+    forall c (valu: bval c) (o: P4A.op Hdr_sz) n m phi st2
       (buf2: n_tuple bool (n + P4A.op_size o + m)) (buf2': n_tuple bool (P4A.op_size o)) len1 (buf1: n_tuple bool len1) st1,
       buf2' ~= n_tuple_take_n (P4A.op_size o) (n_tuple_skip_n n buf2) ->
       interp_store_rel (a:=a)
@@ -1268,9 +1268,9 @@ Section WPProofs.
       rewrite IHo1'.
       autorewrite with eval_op.
       unfold P4A.op_size.
-      set (st2' := @ConfRel.P4A.eval_op Hdr equiv1 Hdr_eq_dec Hdr_finite sz st2 o1
+      set (st2' := @ConfRel.P4A.eval_op Hdr equiv1 Hdr_eq_dec Hdr_finite Hdr_sz st2 o1
           (@rewrite_size bool (Nat.min (P4A.op_size o1) (P4A.op_size o1 + P4A.op_size o2)) (P4A.op_size o1)
-             (ConfRel.P4A.eval_op_obligations_obligation_1 Hdr sz o1 o2)
+             (ConfRel.P4A.eval_op_obligations_obligation_1 Hdr Hdr_sz o1 o2)
              (@n_tuple_take_n bool (P4A.op_size o1 + P4A.op_size o2) (P4A.op_size o1) buf2'))).
       assert (Hsz2: n + P4A.op_size o1 + P4A.op_size o2 + m = n + (P4A.op_size o1 + P4A.op_size o2) + m) by Lia.lia.
       pose (ibuf2 := rewrite_size Hsz2 buf2).
@@ -1283,7 +1283,7 @@ Section WPProofs.
         with (n + P4A.op_size o1 + P4A.op_size o2)
         in Heqp by Lia.lia.
       rewrite Heqp in IHo2'.
-      assert (Hst1': st2' = ConfRel.P4A.eval_op Hdr sz st2 o1 ibuf1').
+      assert (Hst1': st2' = ConfRel.P4A.eval_op Hdr Hdr_sz st2 o1 ibuf1').
       {
         unfold st2'.
         change (ConfRel.P4A.eval_op) with P4A.eval_op.
@@ -1344,25 +1344,25 @@ Section WPProofs.
       reflexivity.
       autorewrite with interp_bit_expr.
       unfold n_tuple_slice.
-      replace (n + sz hdr - sz hdr) with n by Lia.lia.
+      replace (n + Hdr_sz hdr - Hdr_sz hdr) with n by Lia.lia.
       rewrite H.
       apply JMeq_trans
-        with (y := n_tuple_skip_n n (n_tuple_take_n (n + sz hdr) buf2)).
+        with (y := n_tuple_skip_n n (n_tuple_take_n (n + Hdr_sz hdr) buf2)).
       + apply t2l_eq.
         rewrite ?t2l_n_tuple_take_n, ?t2l_n_tuple_skip_n.
         rewrite firstn_skipn_comm.
         rewrite ?t2l_n_tuple_take_n, ?t2l_n_tuple_skip_n.
         reflexivity.
       + eapply n_tuple_skip_n_congr; auto.
-        assert (sz hdr > 0) by (apply a).
-        replace (1 + (n + sz hdr - 1)) with (n + sz hdr) by Lia.lia.
+        assert (Hdr_sz hdr > 0) by (apply a).
+        replace (1 + (n + Hdr_sz hdr - 1)) with (n + Hdr_sz hdr) by Lia.lia.
         reflexivity.
     - simpl.
       intros.
-      pose proof (expr_to_bit_expr_sound c Right valu (sz lhs) rhs _ buf1 st1 _ buf2 st2).
+      pose proof (expr_to_bit_expr_sound c Right valu (Hdr_sz lhs) rhs _ buf1 st1 _ buf2 st2).
       simpl in *.
-      destruct (P4A.eval_expr Hdr sz (sz lhs) _ rhs) eqn:?.
-      assert (sz lhs = @be_size Hdr sz c len1 (n + 0 + m) (expr_to_bit_expr Right rhs)).
+      destruct (P4A.eval_expr Hdr Hdr_sz (Hdr_sz lhs) _ rhs) eqn:?.
+      assert (Hdr_sz lhs = @be_size Hdr Hdr_sz c len1 (n + 0 + m) (expr_to_bit_expr Right rhs)).
       {
         inversion H0.
         apply v_inj; eauto.
@@ -1806,7 +1806,7 @@ Section WPProofs.
     autorewrite with interp_store_rel.
     destruct (eq_dec _ _).
     - intuition.
-      + assert (Hr: eq_rect (be_size sz b1 b2 e1) (n_tuple bool) (interp_bit_expr e1 valu buf1 buf2 st1 st2) (be_size sz b1 b2 e2) e ~= interp_bit_expr e2 valu buf1 buf2 st1 st2)
+      + assert (Hr: eq_rect (be_size Hdr_sz b1 b2 e1) (n_tuple bool) (interp_bit_expr e1 valu buf1 buf2 st1 st2) (be_size Hdr_sz b1 b2 e2) e ~= interp_bit_expr e2 valu buf1 buf2 st1 st2)
           by now rewrite H.
         eapply JMeq_trans; try eapply Hr.
         clear H.
@@ -1825,7 +1825,7 @@ Section WPProofs.
   Qed.
 
   Section PatCondInd.
-    Variable (P: forall ty, P4A.cond sz ty -> P4A.pat ty -> Prop).
+    Variable (P: forall ty, P4A.cond Hdr_sz ty -> P4A.pat ty -> Prop).
     Variable (HExprExact:
                 forall {n e v},
                   P (P4A.TBits n) (P4A.CExpr e) (P4A.PExact v)).
@@ -1843,9 +1843,9 @@ Section WPProofs.
           HPair (pat_cond_ind _ e1 p1) (pat_cond_ind _ e2 p2) }.
   End PatCondInd.
 
-  Definition pat_cond_ok ty (cond: P4A.cond sz ty) pat :=
+  Definition pat_cond_ok ty (cond: P4A.cond Hdr_sz ty) pat :=
     forall ctx st1 st2 si (valu: bval ctx) b1 (buf1: n_tuple bool b1) b2 (buf2: n_tuple bool b2),
-      P4A.match_pat Hdr sz (pick si (st1, st2)) cond pat = true <->
+      P4A.match_pat Hdr Hdr_sz (pick si (st1, st2)) cond pat = true <->
       interp_store_rel (a:=a) (pat_cond si pat cond) valu buf1 buf2 st1 st2.
 
   Lemma val_to_bit_expr_interp:
@@ -1873,8 +1873,8 @@ Section WPProofs.
   Qed.
 
   Lemma pat_cond_safe:
-    forall ty (cond: P4A.cond sz ty) pat ctx st1 st2 si (valu: bval ctx) b1 (buf1: n_tuple bool b1) b2 (buf2: n_tuple bool b2),
-      P4A.match_pat Hdr sz (pick si (st1, st2)) cond pat = true <->
+    forall ty (cond: P4A.cond Hdr_sz ty) pat ctx st1 st2 si (valu: bval ctx) b1 (buf1: n_tuple bool b1) b2 (buf2: n_tuple bool b2),
+      P4A.match_pat Hdr Hdr_sz (pick si (st1, st2)) cond pat = true <->
       interp_store_rel (a:=a) (pat_cond si pat cond) valu buf1 buf2 st1 st2.
   Proof.
     intros ty cond pat.
@@ -1888,8 +1888,8 @@ Section WPProofs.
         subst v.
         intuition.
         set (be := expr_to_bit_expr si e).
-        assert (ConfRel.P4A.eval_expr Hdr sz n (pick si (st1, st2)) e ~=
-                P4A.VBits (be_size sz _ _ be) (interp_bit_expr (a:=a) be valu buf1 buf2 st1 st2))
+        assert (ConfRel.P4A.eval_expr Hdr Hdr_sz n (pick si (st1, st2)) e ~=
+                P4A.VBits (be_size Hdr_sz _ _ be) (interp_bit_expr (a:=a) be valu buf1 buf2 st1 st2))
           by eapply expr_to_bit_expr_sound.
         eapply JMeq_trans;
           [|symmetry; apply val_to_bit_expr_interp].
@@ -1913,8 +1913,8 @@ Section WPProofs.
   Qed.
 
   Lemma cases_cond_safe:
-    forall ty (cond: P4A.cond sz ty) cases default ctx st1 st2 s si (valu: bval ctx) b1 (buf1: n_tuple bool b1) b2 (buf2: n_tuple bool b2),
-      P4A.eval_sel St Hdr sz (pick si (st1, st2)) cond cases default = s ->
+    forall ty (cond: P4A.cond Hdr_sz ty) cases default ctx st1 st2 s si (valu: bval ctx) b1 (buf1: n_tuple bool b1) b2 (buf2: n_tuple bool b2),
+      P4A.eval_sel St Hdr Hdr_sz (pick si (st1, st2)) cond cases default = s ->
       interp_store_rel (a:=a) (cases_cond si cond s cases default) valu buf1 buf2 st1 st2.
   Proof.
     induction cases as [|c cases]; simpl; intros.
@@ -1943,7 +1943,7 @@ Section WPProofs.
 
   Lemma trans_cond_safe:
     forall t si c st1 st2 s (valu: bval c) b1 (buf1: n_tuple bool b1) b2 (buf2: n_tuple bool b2),
-      P4A.eval_trans St Hdr sz (pick si (st1, st2)) t = s ->
+      P4A.eval_trans St Hdr Hdr_sz (pick si (st1, st2)) t = s ->
       interp_store_rel (a:=a) (trans_cond si t s) valu buf1 buf2 st1 st2.
   Proof.
     induction t; simpl; intros.
@@ -2434,7 +2434,7 @@ Section WPProofs.
 
   Lemma weaken_expr_size:
     forall c n (e: bit_expr Hdr c) l1 l2,
-      be_size sz l1 l2 (weaken_bit_expr n e) = be_size sz l1 l2 e.
+      be_size Hdr_sz l1 l2 (weaken_bit_expr n e) = be_size Hdr_sz l1 l2 e.
   Proof.
     induction e; intros; try destruct a0; simpl; auto.
     rewrite !IHe.
@@ -2464,8 +2464,8 @@ Section WPProofs.
       assert (Hvv: v1 ~= v2) by eauto.
       revert Hvv.
       generalize v1 as x1, v2 as x2.
-      generalize (be_size sz l1 l2 (weaken_bit_expr n e)).
-      generalize (be_size sz l1 l2 e).
+      generalize (be_size Hdr_sz l1 l2 (weaken_bit_expr n e)).
+      generalize (be_size Hdr_sz l1 l2 e).
       intros.
       inversion Hvv.
       apply n_tuple_inj in H0.
@@ -2487,10 +2487,10 @@ Section WPProofs.
       revert Hv1 Hv2.
       generalize v11 as x11, v12 as x12.
       generalize v21 as x21, v22 as x22.
-      generalize (be_size sz l1 l2 (weaken_bit_expr n e1)).
-      generalize (be_size sz l1 l2 e1).
-      generalize (be_size sz l1 l2 (weaken_bit_expr n e2)).
-      generalize (be_size sz l1 l2 e2).
+      generalize (be_size Hdr_sz l1 l2 (weaken_bit_expr n e1)).
+      generalize (be_size Hdr_sz l1 l2 e1).
+      generalize (be_size Hdr_sz l1 l2 (weaken_bit_expr n e2)).
+      generalize (be_size Hdr_sz l1 l2 e2).
       intros.
       inversion Hv1.
       inversion Hv2.
@@ -2526,8 +2526,8 @@ Section WPProofs.
         revert e.
         revert e0.
         rewrite !weaken_expr_size.
-        generalize (be_size sz l1 l2 e2).
-        generalize (be_size sz l1 l2 e1).
+        generalize (be_size Hdr_sz l1 l2 e2).
+        generalize (be_size Hdr_sz l1 l2 e1).
         intros.
         subst n0.
         rewrite He1, He2.


### PR DESCRIPTION
This is prep for the automata refactor. It also means automata-related identifiers no longer clash with autogenerated hypothesis names (like H, H1, H2) or the successor constructor for nat (S, previously written Datatypes.S in a lot of places).

I didn't touch any of the benchmarks so some of them still have these problems in their local definitions.